### PR TITLE
Fix warnings in unit tests

### DIFF
--- a/test/test_categorical.py
+++ b/test/test_categorical.py
@@ -50,7 +50,7 @@ class TestCategorical(unittest.TestCase):
     def test_multi_factor_init_values(self):
         values_1 = np.random.rand(5, 4)
         values_2 = np.random.rand(4, 3)
-        values = np.array([values_1, values_2])
+        values = np.array([values_1, values_2], dtype=object)
         c = Categorical(values=values)
         self.assertEqual(c.shape, (2,))
         self.assertEqual(c[0].shape, (5, 4))
@@ -59,7 +59,7 @@ class TestCategorical(unittest.TestCase):
     def test_multi_factor_init_values_expand(self):
         values_1 = np.random.rand(5)
         values_2 = np.random.rand(4)
-        values = np.array([values_1, values_2])
+        values = np.array([values_1, values_2], dtype=object)
         c = Categorical(values=values)
         self.assertEqual(c.shape, (2,))
         self.assertEqual(c[0].shape, (5, 1))
@@ -68,7 +68,7 @@ class TestCategorical(unittest.TestCase):
     def test_normalize_multi_factor(self):
         values_1 = np.random.rand(5)
         values_2 = np.random.rand(4, 3)
-        values = np.array([values_1, values_2])
+        values = np.array([values_1, values_2], dtype=object)
         c = Categorical(values=values)
         c.normalize()
         self.assertTrue(c.is_normalized())
@@ -157,14 +157,14 @@ class TestCategorical(unittest.TestCase):
         # values are already normalized
         values_1 = np.array([1.0, 0.0])
         values_2 = np.array([0.0, 1.0, 0.0])
-        values = np.array([values_1, values_2])
+        values = np.array([values_1, values_2], dtype=object)
         c = Categorical(values=values)
         self.assertTrue(np.isclose(np.array([0, 1]), c.sample()).all())
 
         # values are not normalized
         values_1 = np.array([10.0, 0.0])
         values_2 = np.array([0.0, 10.0, 0.0])
-        values = np.array([values_1, values_2])
+        values = np.array([values_1, values_2], dtype=object)
         c = Categorical(values=values)
         self.assertTrue(np.isclose(np.array([0, 1]), c.sample()).all())
 

--- a/test/test_dirichlet.py
+++ b/test/test_dirichlet.py
@@ -50,7 +50,7 @@ class TestDirichlet(unittest.TestCase):
     def test_multi_factor_init_values(self):
         values_1 = np.random.rand(5, 4)
         values_2 = np.random.rand(4, 3)
-        values = np.array([values_1, values_2])
+        values = np.array([values_1, values_2], dtype=object)
         d = Dirichlet(values=values)
         self.assertEqual(d.shape, (2,))
         self.assertEqual(d[0].shape, (5, 4))
@@ -59,7 +59,7 @@ class TestDirichlet(unittest.TestCase):
     def test_multi_factor_init_values_expand(self):
         values_1 = np.random.rand(5)
         values_2 = np.random.rand(4)
-        values = np.array([values_1, values_2])
+        values = np.array([values_1, values_2], dtype=object)
         d = Dirichlet(values=values)
         self.assertEqual(d.shape, (2,))
         self.assertEqual(d[0].shape, (5, 1))
@@ -68,7 +68,7 @@ class TestDirichlet(unittest.TestCase):
     def test_normalize_multi_factor(self):
         values_1 = np.random.rand(5)
         values_2 = np.random.rand(4, 3)
-        values = np.array([values_1, values_2])
+        values = np.array([values_1, values_2], dtype=object)
         d = Dirichlet(values=values)
         normed = Categorical(values=d.mean(return_numpy=True))
         self.assertTrue(normed.is_normalized())

--- a/test/test_learning.py
+++ b/test/test_learning.py
@@ -351,12 +351,14 @@ class TestLearning(unittest.TestCase):
         l_rate = 1.0
         B = Categorical(
             values=np.array(
-                [np.random.rand(ns, ns, n_control[factor]) for factor, ns in enumerate(n_states)]
+                [np.random.rand(ns, ns, n_control[factor]) for factor, ns in enumerate(n_states)], dtype=object
             )
         )
         B.normalize()
         pB = Dirichlet(
-            values=np.array([np.ones_like(B[factor].values) for factor in range(len(n_states))])
+            values=np.array(
+                [np.ones_like(B[factor].values) for factor in range(len(n_states))], dtype=object
+            )
         )
         action = np.array([np.random.randint(nc) for nc in n_control])
         pB_updated = learning.update_transition_dirichlet(
@@ -389,12 +391,14 @@ class TestLearning(unittest.TestCase):
 
         B = Categorical(
             values=np.array(
-                [np.random.rand(ns, ns, n_control[factor]) for factor, ns in enumerate(n_states)]
+                [np.random.rand(ns, ns, n_control[factor]) for factor, ns in enumerate(n_states)], dtype=object
             )
         )
         B.normalize()
         pB = Dirichlet(
-            values=np.array([np.ones_like(B[factor].values) for factor in range(len(n_states))])
+            values=np.array(
+                [np.ones_like(B[factor].values) for factor in range(len(n_states))], dtype=object
+            )
         )
 
         action = np.array([np.random.randint(nc) for nc in n_control])
@@ -430,12 +434,14 @@ class TestLearning(unittest.TestCase):
         factors_to_update = [0, 2]
         B = Categorical(
             values=np.array(
-                [np.random.rand(ns, ns, n_control[factor]) for factor, ns in enumerate(n_states)]
+                [np.random.rand(ns, ns, n_control[factor]) for factor, ns in enumerate(n_states)], dtype=object
             )
         )
         B.normalize()
         pB = Dirichlet(
-            values=np.array([np.ones_like(B[factor].values) for factor in range(len(n_states))])
+            values=np.array(
+                [np.ones_like(B[factor].values) for factor in range(len(n_states))], dtype=object
+            )
         )
         action = np.array([np.random.randint(nc) for nc in n_control])
         pB_updated = learning.update_transition_dirichlet(


### PR DESCRIPTION
This PR adds the optional `dtype=object` argument to `np.array(...)` when the input lists/arrays are of different dimensions
in order to suppress warnings when running tests.

We should revisit how arrays of different dimensions are handled in general, it is likely that an abstraction exists which will be safer and easier to use/test