### PR TITLE
Compute VFE of policies in run_mmp_v2

### DIFF
--- a/pymdp/core/inference.py
+++ b/pymdp/core/inference.py
@@ -50,9 +50,11 @@ def update_posterior_states_v2(
     ll_seq = get_joint_likelihood_seq(A, prev_obs, num_states)
 
     qs_seq_pi = utils.obj_array(len(policies))
+    F = np.zeros(len(policies)) # variational free energy of policies
+
     for p_idx, policy in enumerate(policies):
         # get sequence and the free energy for policy
-        qs_seq_pi[p_idx] = run_mmp_v2(
+        qs_seq_pi[p_idx], F[p_idx] = run_mmp_v2(
             A,
             B,
             ll_seq,
@@ -64,7 +66,7 @@ def update_posterior_states_v2(
         )
 
 
-    return qs_seq_pi
+    return qs_seq_pi, F
 
 def average_states_over_policies(qs_pi, q_pi):
     """

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -73,7 +73,7 @@ class Inference(unittest.TestCase):
         ]
         prior = rand_dist_states(num_states)
 
-        qs_seq_pi = update_posterior_states_v2(A, B, prev_obs, policies, prev_actions, prior=prior)
+        qs_seq_pi, VFE_policies = update_posterior_states_v2(A, B, prev_obs, policies, prev_actions, prior=prior)
 
         qs_seq_pi_future = utils.obj_array(num_policies)
         for p_idx in range(num_policies):
@@ -99,7 +99,7 @@ class Inference(unittest.TestCase):
             prior = None,
             pA=None,
             pB=None,
-            F = None,
+            F = VFE_policies,
             E = None,
             gamma=16.0,
             return_numpy=True,


### PR DESCRIPTION
I added computation of variational free energy of the policy under consideration in `run_mmp_v2.py`, which is now a second return from the function. Also changed the test files to accommodate the new return.