### PR TITLE
Added computation of policy VFE in case of fixed point MMP 

### DIFF
--- a/pymdp/core/algos/mmp_v2.py
+++ b/pymdp/core/algos/mmp_v2.py
@@ -11,7 +11,7 @@ __author__: Conor Heins, Beren Millidge, Alexander Tschantz, Brennan Klein
 import numpy as np
 
 from pymdp.core.utils import to_arr_of_arr, get_model_dimensions, obj_array
-from pymdp.core.maths import spm_dot, spm_norm, softmax
+from pymdp.core.maths import spm_dot, spm_norm, softmax, calc_free_energy
 import copy
 
 
@@ -107,5 +107,12 @@ def run_mmp_v2(
                 else:
                     # @NOTE: We need to figure out how to calculate the VFE here
                     qs_seq[t][f] = softmax(lnA + lnB_past + lnB_future)
+            
+            if not grad_descent:
+                if t < past_len:
+                    F += calc_free_energy(qs_seq[t], prior, num_factors, likelihood = np.log(ll_seq[t] + 1e-16) )
+                else:
+                    F += calc_free_energy(qs_seq[t], prior, num_factors)
+
 
     return qs_seq, F


### PR DESCRIPTION
I don't have a way of validating this computation yet (any ideas @alec-tschantz @BerenMillidge), since spm_MDP_VB_X doesn't use fixed points when updating beliefs, but the computation of the free energy "works" in terms of argument-handling. But would be good to get a second pair of eyes on that / discuss how we can make sure the maths is correct.