### PR TITLE
Edits to spm_dot

### DIFF
--- a/experimental/scratch/mmp_og.py
+++ b/experimental/scratch/mmp_og.py
@@ -130,14 +130,17 @@ def run_mmp(
     # likelihood of observations under configurations of hidden causes (over time)
     likelihood = np.empty(len(obs_range), dtype=object)
     for t in range(len(obs_range)):
-        likelihood_t = np.ones(tuple(n_states))
+        # likelihood_t = np.ones(tuple(n_states))
 
-        if n_modalities == 1:
-            likelihood_t *= spm_dot(A, obs_t[obs_range[t]], obs_mode=True)
-        else:
-            for modality in range(n_modalities):
-                likelihood_t *= spm_dot(A[modality], obs_t[obs_range[t]][modality], obs_mode=True)
-        print(f"likelihood (pre-logging) {likelihood_t}")
+        # if n_modalities == 1:
+        #     likelihood_t *= spm_dot(A, obs_t[obs_range[t]], obs_mode=True)
+        # else:
+        #     for modality in range(n_modalities):
+        #         likelihood_t *= spm_dot(A[modality], obs_t[obs_range[t]][modality], obs_mode=True)
+        
+        likelihood_t = get_joint_likelihood(A, obs_t[obs_range[t]], n_states)
+
+        # print(f"likelihood (pre-logging) {likelihood_t}")
         # likelihood[t] = np.log(likelihood_t + 1e-16) # The Thomas Parr MMP version, you log the likelihood first
         likelihood[t] = likelihood_t # Karl SPM version, logging doesn't happen until *after* the dotting with the posterior
 

--- a/pymdp/core/algos/fpi.py
+++ b/pymdp/core/algos/fpi.py
@@ -8,7 +8,7 @@ __author__: Conor Heins, Beren Millidge, Alexander Tschantz, Brennan Klein
 """
 
 import numpy as np
-from pymdp.core.maths import spm_dot, softmax, calc_free_energy
+from pymdp.core.maths import spm_dot, get_joint_likelihood, softmax, calc_free_energy
 
 
 def run_fpi(A, obs, n_observations, n_states, prior=None, num_iter=10, dF=1.0, dF_tol=0.001):
@@ -59,12 +59,15 @@ def run_fpi(A, obs, n_observations, n_states, prior=None, num_iter=10, dF=1.0, d
         onto a single joint likelihood over hidden factors [size n_states]
     """
 
-    likelihood = np.ones(tuple(n_states))
-    if n_modalities is 1:
-        likelihood *= spm_dot(A, obs, obs_mode=True)
-    else:
-        for modality in range(n_modalities):
-            likelihood *= spm_dot(A[modality], obs[modality], obs_mode=True)
+
+    # likelihood = np.ones(tuple(n_states))
+    # if n_modalities is 1:
+    #     likelihood *= spm_dot(A, obs, obs_mode=True)
+    # else:
+    #     for modality in range(n_modalities):
+    #         likelihood *= spm_dot(A[modality], obs[modality], obs_mode=True)
+    likelihood = get_joint_likelihood(A, obs, n_states)
+
     likelihood = np.log(likelihood + 1e-16)
 
     """
@@ -202,13 +205,14 @@ def run_fpi_faster(A, obs, n_observations, n_states, prior=None, num_iter=10, dF
         onto a single joint likelihood over hidden factors [size n_states]
     """
 
-    likelihood = np.ones(tuple(n_states))
+    # likelihood = np.ones(tuple(n_states))
 
-    if n_modalities is 1:
-        likelihood *= spm_dot(A, obs, obs_mode=True)
-    else:
-        for modality in range(n_modalities):
-            likelihood *= spm_dot(A[modality], obs[modality], obs_mode=True)
+    # if n_modalities is 1:
+    #     likelihood *= spm_dot(A, obs, obs_mode=True)
+    # else:
+    #     for modality in range(n_modalities):
+    #         likelihood *= spm_dot(A[modality], obs[modality], obs_mode=True)
+    likelihood = get_joint_likelihood(A, obs, n_states)
     likelihood = np.log(likelihood + 1e-16)
 
     """

--- a/pymdp/core/algos/mmp.py
+++ b/pymdp/core/algos/mmp.py
@@ -11,7 +11,7 @@ import numpy as np
 import sys
 import pathlib
 
-from pymdp.core.maths import spm_dot, spm_norm, softmax, calc_free_energy
+from pymdp.core.maths import spm_dot, get_joint_likelihood, spm_norm, softmax, calc_free_energy
 from pymdp.core import utils
 
 
@@ -147,13 +147,15 @@ def run_mmp(
     # likelihood of observations under configurations of hidden states (over time)
     likelihood = np.empty(len(obs_range), dtype=object)
     for t, obs in enumerate(obs_range):
-        likelihood_t = np.ones(tuple(num_states))
+        # likelihood_t = np.ones(tuple(num_states))
 
-        if num_modalities == 1:
-            likelihood_t *= spm_dot(A[0], obs_t[obs], obs_mode=True)
-        else:
-            for modality in range(num_modalities):
-                likelihood_t *= spm_dot(A[modality], obs_t[obs][modality], obs_mode=True)
+        # if num_modalities == 1:
+        #     likelihood_t *= spm_dot(A[0], obs_t[obs], obs_mode=True)
+        # else:
+        #     for modality in range(num_modalities):
+        #         likelihood_t *= spm_dot(A[modality], obs_t[obs][modality], obs_mode=True)
+        
+        likelihood_t = get_joint_likelihood(A, obs_t, num_states)
 
         # The Thomas Parr MMP version, you log the likelihood first
         # likelihood[t] = np.log(likelihood_t + 1e-16)

--- a/test/test_categorical.py
+++ b/test/test_categorical.py
@@ -184,7 +184,8 @@ class TestCategorical(unittest.TestCase):
         result_3 = mat_contents["result3"]
 
         A = Categorical(values=A)
-        result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        # result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        result_1_py = A.dot_likelihood(obs, return_numpy=True)
         self.assertTrue(np.isclose(result_1, result_1_py).all())
 
         result_2_py = A.dot(states, return_numpy=True)
@@ -210,7 +211,8 @@ class TestCategorical(unittest.TestCase):
         result_3 = mat_contents["result3"]
 
         A = Categorical(values=A)
-        result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        # result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        result_1_py = A.dot_likelihood(obs, return_numpy=True)
         self.assertTrue(np.isclose(result_1, result_1_py).all())
 
         result_2_py = A.dot(states, return_numpy=True)
@@ -235,7 +237,8 @@ class TestCategorical(unittest.TestCase):
         result_3 = mat_contents["result3"]
 
         A = Categorical(values=A)
-        result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        # result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        result_1_py = A.dot_likelihood(obs, return_numpy=True)
         self.assertTrue(np.isclose(result_1, result_1_py).all())
 
         result_2_py = A.dot(states, return_numpy=True)
@@ -262,7 +265,8 @@ class TestCategorical(unittest.TestCase):
         result_3 = mat_contents["result3"]
 
         A = Categorical(values=A)
-        result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        # result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        result_1_py = A.dot_likelihood(obs, return_numpy=True)
         self.assertTrue(np.isclose(result_1, result_1_py).all())
 
         result_2_py = A.dot(states_array_version, return_numpy=True)
@@ -293,7 +297,8 @@ class TestCategorical(unittest.TestCase):
         result_3 = mat_contents["result3"]
 
         A = Categorical(values=A)
-        result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        # result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        result_1_py = A.dot_likelihood(obs, return_numpy=True)
         self.assertTrue(np.isclose(result_1, result_1_py).all())
 
         result_2_py = A.dot(states_array_version, return_numpy=True)
@@ -320,7 +325,8 @@ class TestCategorical(unittest.TestCase):
         result_3 = mat_contents["result3"]
 
         A = Categorical(values=A)
-        result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        # result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        result_1_py = A.dot_likelihood(obs, return_numpy=True)
         self.assertTrue(np.isclose(result_1, result_1_py).all())
 
         result_2_py = A.dot(states_array_version, return_numpy=True)
@@ -347,7 +353,8 @@ class TestCategorical(unittest.TestCase):
         result_3 = mat_contents["result3"]
 
         A = Categorical(values=A)
-        result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        # result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        result_1_py = A.dot_likelihood(obs, return_numpy=True)
         self.assertTrue(np.isclose(result_1, result_1_py).all())
 
         result_2_py = A.dot(states_array_version, return_numpy=True)
@@ -376,7 +383,8 @@ class TestCategorical(unittest.TestCase):
         result_3 = mat_contents["result3"]
 
         A = Categorical(values=A)
-        result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        # result_1_py = A.dot(obs, obs_mode=True, return_numpy=True)
+        result_1_py = A.dot_likelihood(obs, return_numpy=True)
         self.assertTrue(np.isclose(result_1, result_1_py).all())
 
         result_2_py = A.dot(states_array_version, return_numpy=True)


### PR DESCRIPTION
Terser implementation of `spm_dot` by first multiplying marginals onto single likelihood tensor, then summing across all desired dimensions. Also curious to look into `np.einsum` or `np.tensordot` as possible alternative implementations (following suggestion of @dimarkov).

Also made dissociable `dot_likelihood` method of `Categorical` class