### PR TITLE
Fixes bug when reading A matrices with > 2 hidden state factors from Excel

### DIFF
--- a/pymdp/core/utils.py
+++ b/pymdp/core/utils.py
@@ -441,11 +441,11 @@ def create_B_matrix_stubs(model_labels):
 
     return B_matrices
 
-def read_A_matrix(path):
+def read_A_matrix(path, num_hidden_state_factors):
     raw_table = pd.read_excel(path, header=None)
     level_counts = {
         "index": raw_table.iloc[0, :].dropna().index[0] + 1,
-        "header": raw_table.iloc[0, :].dropna().index[0] + 1,
+        "header": raw_table.iloc[0, :].dropna().index[0] + num_hidden_state_factors - 1,
     }
     return pd.read_excel(
         path,

--- a/test/test_wrappers.py
+++ b/test/test_wrappers.py
@@ -42,12 +42,14 @@ class TestWrappers(unittest.TestCase):
                 "sprinkler_state": ["on", "off"],
             },
         }
+
+        num_hidden_state_factors = len(model_labels["states"])
         
         expected_A_matrix_stub = create_A_matrix_stub(model_labels)
     
         temporary_file_path = (tmp_path / "A_matrix_stub.xlsx").resolve()
         expected_A_matrix_stub.to_excel(temporary_file_path)
-        actual_A_matrix_stub = read_A_matrix(temporary_file_path)
+        actual_A_matrix_stub = read_A_matrix(temporary_file_path, num_hidden_state_factors)
 
         os.remove(temporary_file_path)
 


### PR DESCRIPTION
Offsets the first row read in from an Excel file based on the number of hidden state factors