### PR TITLE
D vector learning

### DIFF
--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -277,9 +277,9 @@ class Agent(object):
 
         begin_horizon_step = self.curr_timestep - self.inference_horizon
         if self.edge_handling_params['use_BMA'] and (begin_horizon_step >= 0):
-            try:
+            if hasattr(self, "q_pi_hist"):
                 self.latest_belief = inference.average_states_over_policies(last_belief, self.q_pi_hist[begin_horizon_step]) # average the earliest marginals together using contemporaneous posterior over policies (`self.q_pi_hist[0]`)
-            except:
+            else:
                 self.latest_belief = inference.average_states_over_policies(last_belief, self.q_pi) # average the earliest marginals together using posterior over policies (`self.q_pi`)
         else:
             self.latest_belief = last_belief
@@ -529,18 +529,14 @@ class Agent(object):
             if self.edge_handling_params['use_BMA']:
                 qs_t0 = self.latest_belief
             elif self.edge_handling_params['policy_sep_prior']:
-                # get beliefs about hidden states at the time at the beginning of the inference horizon
-                # qs_pi_t0 = utils.obj_array(len(self.policies))
-                # for p_i, _ in enumerate(self.policies):
-                #     qs_pi_t0[p_i] = copy.deepcopy(self.qs[p_i][0])
-
+              
                 qs_pi_t0 = self.latest_belief
 
                 # get beliefs about policies at the time at the beginning of the inference horizon
-                try:
+                if hasattr(self, "q_pi_hist"):
                     begin_horizon_step = max(0, self.curr_timestep - self.inference_horizon)
                     q_pi_t0 = np.copy(self.q_pi_hist[begin_horizon_step])
-                except:
+                else:
                     q_pi_t0 = np.copy(self.q_pi)
             
                 qs_t0 = inference.average_states_over_policies(qs_pi_t0,q_pi_t0) # beliefs about hidden states at the first timestep of the inference horizon

--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -26,6 +26,7 @@ class Agent(object):
         pB=None,
         C=None,
         D=None,
+        pD = None,
         num_states=None,
         num_obs=None,
         num_controls=None,
@@ -44,8 +45,10 @@ class Agent(object):
         lr_pA=1.0,
         factors_to_learn="all",
         lr_pB=1.0,
+        lr_pD=1.0,
         use_BMA = True,
-        policy_sep_prior = False
+        policy_sep_prior = False,
+        save_belief_hist = False
     ):
 
         ### Constant parameters ###
@@ -63,6 +66,7 @@ class Agent(object):
         self.lr_pA = lr_pA
         self.factors_to_learn = factors_to_learn
         self.lr_pB = lr_pB
+        self.lr_pD = lr_pD
 
         """ Initialise observation model (A matrices) """
         if not isinstance(A, np.ndarray):
@@ -145,7 +149,13 @@ class Agent(object):
                 )
             self.D = utils.to_arr_of_arr(D)
         else:
-            self.D = self._construct_D_prior()
+            if pD is not None:
+                self.D = utils.norm_dist_obj_arr(pD)
+            else:
+                self.D = self._construct_D_prior()
+        
+        """ Assigning prior parameters on initial hidden states (pD vectors) """
+        self.pD = pD
 
         self.edge_handling_params = {}
         self.edge_handling_params['use_BMA'] = use_BMA # creates a 'D-like' moving prior
@@ -175,6 +185,10 @@ class Agent(object):
             self.inference_algo = inference_algo
             self.inference_params = self._get_default_params()
             self.inference_horizon = inference_horizon
+
+        if save_belief_hist:
+            self.qs_hist = []
+            self.q_pi_hist = []
         
         self.prev_obs = []
         self.reset()
@@ -261,8 +275,12 @@ class Agent(object):
             for p_i, _ in enumerate(self.policies):
                 last_belief[p_i] = copy.deepcopy(self.qs[p_i][0])
 
-        if self.edge_handling_params['use_BMA'] and (self.curr_timestep - self.inference_horizon >= 0):
-            self.latest_belief = inference.average_states_over_policies(last_belief, self.q_pi) # average the earliest marginals together using posterior over policies (`self.q_pi`)
+        begin_horizon_step = self.curr_timestep - self.inference_horizon
+        if self.edge_handling_params['use_BMA'] and (begin_horizon_step >= 0):
+            try:
+                self.latest_belief = inference.average_states_over_policies(last_belief, self.q_pi_hist[begin_horizon_step]) # average the earliest marginals together using contemporaneous posterior over policies (`self.q_pi_hist[0]`)
+            except:
+                self.latest_belief = inference.average_states_over_policies(last_belief, self.q_pi) # average the earliest marginals together using posterior over policies (`self.q_pi`)
         else:
             self.latest_belief = last_belief
 
@@ -340,7 +358,9 @@ class Agent(object):
             )
 
             self.F = F # variational free energy of each policy  
-    
+
+        if hasattr(self, "qs_hist"):
+            self.qs_hist.append(qs)
         self.qs = qs
 
         return qs
@@ -386,7 +406,10 @@ class Agent(object):
             )
 
             self.F = F # variational free energy of each policy  
-    
+
+        if hasattr(self, "qs_hist"):
+            self.qs_hist.append(qs)
+
         self.qs = qs
 
         return qs, xn, vn
@@ -428,6 +451,11 @@ class Agent(object):
                 gamma = self.gamma
             )
 
+        if hasattr(self, "q_pi_hist"):
+            self.q_pi_hist.append(q_pi)
+            if len(self.q_pi_hist) > self.inference_horizon:
+                self.q_pi_hist = self.q_pi_hist[-(self.inference_horizon-1):]
+
         self.q_pi = q_pi
         self.efe = efe
         return q_pi, efe
@@ -444,6 +472,9 @@ class Agent(object):
         return action
 
     def update_A(self, obs):
+        """
+        Update posterior beliefs about Dirichlet parameters that parameterise the observation likelihood 
+        """
 
         pA_updated = learning.update_likelihood_dirichlet(
             self.pA, 
@@ -460,6 +491,9 @@ class Agent(object):
         return pA_updated
 
     def update_B(self, qs_prev):
+        """
+        Update posterior beliefs about Dirichlet parameters that parameterise the transition likelihood 
+        """
 
         pB_updated = learning.update_transition_dirichlet(
             self.pB,
@@ -475,6 +509,48 @@ class Agent(object):
         self.B = utils.norm_dist_obj_arr(self.pB) 
 
         return pB_updated
+    
+    def update_D(self, qs_t0 = None):
+        """
+        Update posterior beliefs about Dirichlet parameters that parameterise the prior over initial hidden states
+        """
+        
+        if self.inference_algo == "VANILLA":
+            
+            if qs_t0 is None:
+                
+                try:
+                    qs_t0 = self.qs_hist[0]
+                except ValueError:
+                    print("qs_t0 must either be passed as argument to `update_D` or `save_belief_hist` must be set to True!")             
+
+        elif self.inference_algo == "MMP":
+            
+            if self.edge_handling_params['use_BMA']:
+                qs_t0 = self.latest_belief
+            elif self.edge_handling_params['policy_sep_prior']:
+                # get beliefs about hidden states at the time at the beginning of the inference horizon
+                # qs_pi_t0 = utils.obj_array(len(self.policies))
+                # for p_i, _ in enumerate(self.policies):
+                #     qs_pi_t0[p_i] = copy.deepcopy(self.qs[p_i][0])
+
+                qs_pi_t0 = self.latest_belief
+
+                # get beliefs about policies at the time at the beginning of the inference horizon
+                try:
+                    begin_horizon_step = max(0, self.curr_timestep - self.inference_horizon)
+                    q_pi_t0 = np.copy(self.q_pi_hist[begin_horizon_step])
+                except:
+                    q_pi_t0 = np.copy(self.q_pi)
+            
+                qs_t0 = inference.average_states_over_policies(qs_pi_t0,q_pi_t0) # beliefs about hidden states at the first timestep of the inference horizon
+        
+        pD_updated = learning.update_state_prior_dirichlet(self.pD, qs_t0, self.lr_pD, factors = self.factors_to_learn)
+        
+        self.pD = pD_updated
+        self.D = utils.norm_dist_obj_arr(self.pD)
+
+        return pD_updated
 
     def _get_default_params(self):
         method = self.inference_algo

--- a/pymdp/control.py
+++ b/pymdp/control.py
@@ -45,7 +45,7 @@ def update_posterior_policies_mmp(
     `pA`: numpy object array that stores Dirichlet priors over likelihood mappings (one per modality)
     `pB`: numpy object array that stores Dirichlet priors over transition mappings (one per hidden state factor)
     `F` : 1D numpy array that stores variational free energy of each policy 
-    `E` : 1D numpy array that stores prior probability each policy (e.g. 'habits')
+    `E` : 1D numpy array that stores (log) prior probability each policy (e.g. 'habits')
     `gamma`: Float that encodes the precision over policies
     """
 
@@ -100,6 +100,7 @@ def update_posterior_policies(
     use_param_info_gain=False,
     pA=None,
     pB=None,
+    E = None,
     gamma=16.0
 ):
     """ Updates the posterior beliefs about policies based on expected free energy prior
@@ -132,6 +133,7 @@ def update_posterior_policies(
             Dirichlet (both single and multi-factor)]:
             Prior dirichlet parameters for B. Defaults to none, in which case info gain w.r.t. 
             Dirichlet parameters over A is skipped.
+        - `E` : 1D numpy array that stores (log) prior probability each policy (e.g. 'habits')
         - `gamma` [float, defaults to 16.0]:
             Precision over policies, used as the inverse temperature parameter of a softmax transformation 
             of the expected free energies of each policy
@@ -147,6 +149,9 @@ def update_posterior_policies(
     n_policies = len(policies)
     efe = np.zeros(n_policies)
     q_pi = np.zeros((n_policies, 1))
+
+    if E is None:
+        E = np.zeros(n_policies)
 
     for idx, policy in enumerate(policies):
         qs_pi = get_expected_states(qs, B, policy)
@@ -164,7 +169,7 @@ def update_posterior_policies(
             if pB is not None:
                 efe[idx] += calc_pB_info_gain(pB, qs_pi, qs, policy)
 
-    q_pi = softmax(efe * gamma)    
+    q_pi = softmax(efe * gamma + E)    
 
     return q_pi, efe
 

--- a/pymdp/learning.py
+++ b/pymdp/learning.py
@@ -93,3 +93,38 @@ def update_transition_dirichlet(
         pB_updated[factor][:,:,int(actions[factor])] += (lr*dfdb)
 
     return pB_updated
+
+def update_state_prior_dirichlet(
+    pD, qs, lr=1.0, factors="all"
+):
+    """
+    Update Dirichlet parameters that parameterize the hidden state prior of the generative model 
+    (prior beliefs about hidden states at the beginning of the inference window).
+
+    Parameters
+    -----------
+   -  pD [numpy object array]:
+        The prior Dirichlet parameters of the generative model, parameterizing the agent's 
+        beliefs about initial hidden states
+    - qs [numpy object array (where each entry is a numpy 1D array)]:
+        Current marginal posterior beliefs about hidden state factors
+    - lr [float, optional]:
+        Learning rate.
+    - factors [list, optional]:
+        Indices (in terms of range(num_factors)) of the hidden state factors to include in learning.
+        Defaults to 'all', meaning that the priors over initial hidden states for all hidden state factors
+        are updated.
+    """
+
+    num_factors = len(pD)
+
+    pD_updated = copy.deepcopy(pD)
+   
+    if factors == "all":
+        factors = list(range(num_factors))
+
+    for factor in factors:
+        idx = pD[factor] > 0 # only update those state level indices that have some prior probability
+        pD_updated[factor][idx] += (lr * qs[factor][idx])
+       
+    return pD_updated

--- a/pymdp/utils.py
+++ b/pymdp/utils.py
@@ -16,6 +16,14 @@ def sample(probabilities):
     sample_onehot = np.random.multinomial(1, probabilities.squeeze())
     return np.where(sample_onehot == 1)[0][0]
 
+def sample_obj_array(arr):
+    """ 
+    Sample from set of Categorical distributions, stored in the sub-arrays of an object array 
+    """
+    
+    samples = [sample(arr_i) for arr_i in arr]
+
+    return samples
 
 def obj_array(num_arr):
     """


### PR DESCRIPTION
New additions to `pymdp` that support updating dirichlet parameters (`pD`) over prior over initial states. This is the first step towards implementing "structure learning" in `pymdp`, which will consist into doing Bayesian model reduction using a combination of the posterior beliefs about the Dirichlet parameters of the generative model likelihoods (e.g. `pA` or `pB`)  and posterior beliefs about the Dirichlet parameters of the generative model priors (for now, `pD`). 

Additions include:

1. new function for updating `pD` in `learning.py` module
2. New method of `Agent()` class, called `update_D()`, that is compatible with the various sorts of posterior inference schemes available to the`Agent()`. I.e. it should work with both MMP-style inference (where posterior beliefs about both future and past hidden states, under all policies, are entertained) as well as "vanilla" inference (instantaneous posterior beliefs about only the current timestep, unconditioned on policies). 
3. Unit tests for features in points 1) and 2)