### PR TITLE
user-provided `num_controls` assigned to `self.num_controls` in `agent.py`

### DIFF
--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -116,7 +116,9 @@ class Agent(object):
         # If no `num_controls` are given, then this is inferred from the shapes of the input B matrices
         if num_controls == None:
             self.num_controls = [self.B[f].shape[2] for f in range(self.num_factors)]
-
+        else:
+            self.num_controls = num_controls
+        
         # Users have the option to make only certain factors controllable.
         # default behaviour is to make all hidden state factors controllable
         # (i.e. self.num_states == self.num_controls)


### PR DESCRIPTION
If not provided as argument in `Agent` constructor. Please see https://github.com/infer-actively/pymdp/issues/84#issue-1302413950