### PR TITLE
Action precision input to address Issue #81

### DIFF
--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -46,6 +46,7 @@ class Agent(object):
         control_fac_idx=None,
         policies=None,
         gamma=16.0,
+        alpha = 16.0,
         use_utility=True,
         use_states_info_gain=True,
         use_param_info_gain=False,
@@ -67,6 +68,7 @@ class Agent(object):
         # policy parameters
         self.policy_len = policy_len
         self.gamma = gamma
+        self.alpha = alpha
         self.action_selection = action_selection
         self.use_utility = use_utility
         self.use_states_info_gain = use_states_info_gain
@@ -584,7 +586,7 @@ class Agent(object):
         """
 
         action = control.sample_action(
-            self.q_pi, self.policies, self.num_controls, self.action_selection
+            self.q_pi, self.policies, self.num_controls, action_selection = self.action_selection, alpha = self.alpha
         )
 
         self.action = action
@@ -592,6 +594,29 @@ class Agent(object):
         self.step_time()
 
         return action
+    
+    def _sample_action_test(self):
+        """
+        Sample or select a discrete action from the posterior over control states.
+        This function both sets or cachés the action as an internal variable with the agent and returns it.
+        This function also updates time variable (and thus manages consequences of updating the moving reference frame of beliefs)
+        using ``self.step_time()``.
+        
+        Returns
+        ----------
+        action: 1D ``numpy.ndarray``
+            Vector containing the indices of the actions for each control factor
+        """
+
+        action, p_actions = control._sample_action_test(
+            self.q_pi, self.policies, self.num_controls, action_selection = self.action_selection, alpha = self.alpha
+        )
+
+        self.action = action
+
+        self.step_time()
+
+        return action, p_actions
 
     def update_A(self, obs):
         """

--- a/pymdp/control.py
+++ b/pymdp/control.py
@@ -565,7 +565,70 @@ def sample_action(q_pi, policies, num_controls, action_selection="deterministic"
         if action_selection == 'deterministic':
             selected_policy[factor_i] = np.argmax(action_marginals[factor_i])
         elif action_selection == 'stochastic':
-            p_actions = softmax(action_marginals[factor_i] * alpha)
+            log_marginal_f = spm_log_single(action_marginals[factor_i])
+            p_actions = softmax(log_marginal_f * alpha)
             selected_policy[factor_i] = utils.sample(p_actions)
 
     return selected_policy
+
+def _sample_action_test(q_pi, policies, num_controls, action_selection="deterministic", alpha = 16.0):
+    """
+    Computes the marginal posterior over actions and then samples an action from it, one action per control factor.
+    Internal testing version that returns the marginal posterior over actions.
+
+    Parameters
+    ----------
+    q_pi: 1D ``numpy.ndarray``
+        Posterior beliefs over policies, i.e. a vector containing one posterior probability per policy.
+    policies: ``list`` of 2D ``numpy.ndarray``
+        ``list`` that stores each policy as a 2D array in ``policies[p_idx]``. Shape of ``policies[p_idx]`` 
+        is ``(num_timesteps, num_factors)`` where ``num_timesteps`` is the temporal
+        depth of the policy and ``num_factors`` is the number of control factors.
+    num_controls: ``list`` of ``int``
+        ``list`` of the dimensionalities of each control state factor.
+    action_selection: string, default "deterministic"
+        String indicating whether whether the selected action is chosen as the maximum of the posterior over actions,
+        or whether it's sampled from the posterior marginal over actions
+    alpha: float, default 16.0
+        Action selection precision -- the inverse temperature of the softmax that is used to scale the 
+        action marginals before sampling. This is only used if ``action_selection`` argument is "stochastic"
+
+    Returns
+    ----------
+    selected_policy: 1D ``numpy.ndarray``
+        Vector containing the indices of the actions for each control factor
+    p_actions: ``numpy.ndarray`` of dtype object
+        Marginal posteriors over actions, after softmaxing and scaling with action precision. This distribution will be used to sample actions,
+        if``action_selection`` argument is "stochastic"
+    """
+
+    num_factors = len(num_controls)
+
+    action_marginals = utils.obj_array_zeros(num_controls)
+    
+    # weight each action according to its integrated posterior probability over policies and timesteps
+    # for pol_idx, policy in enumerate(policies):
+    #     for t in range(policy.shape[0]):
+    #         for factor_i, action_i in enumerate(policy[t, :]):
+    #             action_marginals[factor_i][action_i] += q_pi[pol_idx]
+    
+    # weight each action according to its integrated posterior probability under all policies at the current timestep
+    for pol_idx, policy in enumerate(policies):
+        for factor_i, action_i in enumerate(policy[0, :]):
+            action_marginals[factor_i][action_i] += q_pi[pol_idx]
+    
+    action_marginals = utils.norm_dist_obj_arr(action_marginals)
+
+    selected_policy = np.zeros(num_factors)
+    p_actions = utils.obj_array_zeros(num_controls)
+    for factor_i in range(num_factors):
+
+        # Either you do this:
+        if action_selection == 'deterministic':
+            selected_policy[factor_i] = np.argmax(action_marginals[factor_i])
+        elif action_selection == 'stochastic':
+            log_marginal_f = spm_log_single(action_marginals[factor_i])
+            p_actions[factor_i] = softmax(log_marginal_f * alpha)
+            selected_policy[factor_i] = utils.sample(p_actions[factor_i])
+
+    return selected_policy, p_actions

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -409,6 +409,36 @@ class TestAgent(unittest.TestCase):
         for factor in range(len(num_states)):
 
             self.assertTrue(np.allclose(pD_test[factor], pD_validation[factor]))
+    
+    def test_agent_with_input_alpha(self):
+        """
+        Test for passing in `alpha` (action sampling precision parameter) as argument to `agent.Agent()` constructor.
+        Test two cases to make sure alpha scaling is working properly, by comparing entropies of action marginals 
+        after computing posterior over actions in cases where alpha is passed in as two different values to the Agent constructor.
+        """
+
+        num_obs = [2]
+        num_states = [2]
+        num_controls = [2]
+        A = utils.to_obj_array(np.eye(num_obs[0], num_states[0]))
+        B = utils.construct_controllable_B(num_states, num_controls)
+        C = utils.to_obj_array(np.array([1.01, 1.0]))
+
+        agent = Agent(A=A, B=B, C=C, alpha = 16.0, action_selection = "stochastic")
+        agent.infer_states(([0]))
+        agent.infer_policies()
+        chosen_action, p_actions1 = agent._sample_action_test()
+
+        agent = Agent(A=A, B=B, C=C, alpha = 0.0, action_selection = "stochastic")
+        agent.infer_states(([0]))
+        agent.infer_policies()
+        chosen_action, p_actions2 = agent._sample_action_test()
+
+        entropy_p_actions1 = -maths.spm_log_single(p_actions1[0]).dot(p_actions1[0])
+        entropy_p_actions2 = -maths.spm_log_single(p_actions2[0]).dot(p_actions2[0])
+
+        self.assertGreater(entropy_p_actions2, entropy_p_actions1)
+
         
 
 


### PR DESCRIPTION
- add option to pass in `alpha` parameter (action precision) to `Agent()` constructor directly
- added unit test to `control.py` for testing new `alpha` input to Agent() feature
- added internal method of `_sample_action_test()` to `Agent()` that returns the action marginals (for use in unit-test)
This should close Issue #81, see https://github.com/infer-actively/pymdp/issues/81