### PR TITLE
`sample_policy()` function in `control.py`

### DIFF
--- a/pymdp/control.py
+++ b/pymdp/control.py
@@ -674,3 +674,46 @@ def sample_policy(q_pi, policies, num_controls, action_selection="deterministic"
         selected_policy[factor_i] = policies[policy_idx][0, factor_i]
 
     return selected_policy
+
+def _sample_policy_test(q_pi, policies, num_controls, action_selection="deterministic", alpha = 16.0):
+    """
+    Test version of sampling a policy from the posterior over policies, taking the action (per control factor) entailed by the first timestep of the selected policy.
+    This test version also returns the probability distribution over policies.
+    Parameters
+    ----------
+    q_pi: 1D ``numpy.ndarray``
+        Posterior beliefs over policies, i.e. a vector containing one posterior probability per policy.
+    policies: ``list`` of 2D ``numpy.ndarray``
+        ``list`` that stores each policy as a 2D array in ``policies[p_idx]``. Shape of ``policies[p_idx]`` 
+        is ``(num_timesteps, num_factors)`` where ``num_timesteps`` is the temporal
+        depth of the policy and ``num_factors`` is the number of control factors.
+    num_controls: ``list`` of ``int``
+        ``list`` of the dimensionalities of each control state factor.
+    action_selection: string, default "deterministic"
+        String indicating whether whether the selected policy is chosen as the maximum of the posterior over policies,
+        or whether it's sampled from the posterior over policies.
+    alpha: float, default 16.0
+        Action selection precision -- the inverse temperature of the softmax that is used to scale the 
+        policy posterior before sampling. This is only used if ``action_selection`` argument is "stochastic"
+
+    Returns
+    ----------
+    selected_policy: 1D ``numpy.ndarray``
+        Vector containing the indices of the actions for each control factor
+    """
+
+    num_factors = len(num_controls)
+
+    if action_selection == "deterministic":
+        policy_idx = np.argmax(q_pi)
+        p_policies = q_pi
+    elif action_selection == "stochastic":
+        log_qpi = spm_log_single(q_pi)
+        p_policies = softmax(log_qpi * alpha)
+        policy_idx = utils.sample(p_policies)
+
+    selected_policy = np.zeros(num_factors)
+    for factor_i in range(num_factors):
+        selected_policy[factor_i] = policies[policy_idx][0, factor_i]
+
+    return selected_policy, p_policies

--- a/pymdp/control.py
+++ b/pymdp/control.py
@@ -632,3 +632,45 @@ def _sample_action_test(q_pi, policies, num_controls, action_selection="determin
             selected_policy[factor_i] = utils.sample(p_actions[factor_i])
 
     return selected_policy, p_actions
+
+def sample_policy(q_pi, policies, num_controls, action_selection="deterministic", alpha = 16.0):
+    """
+    Samples a policy from the posterior over policies, taking the action (per control factor) entailed by the first timestep of the selected policy.
+
+    Parameters
+    ----------
+    q_pi: 1D ``numpy.ndarray``
+        Posterior beliefs over policies, i.e. a vector containing one posterior probability per policy.
+    policies: ``list`` of 2D ``numpy.ndarray``
+        ``list`` that stores each policy as a 2D array in ``policies[p_idx]``. Shape of ``policies[p_idx]`` 
+        is ``(num_timesteps, num_factors)`` where ``num_timesteps`` is the temporal
+        depth of the policy and ``num_factors`` is the number of control factors.
+    num_controls: ``list`` of ``int``
+        ``list`` of the dimensionalities of each control state factor.
+    action_selection: string, default "deterministic"
+        String indicating whether whether the selected policy is chosen as the maximum of the posterior over policies,
+        or whether it's sampled from the posterior over policies.
+    alpha: float, default 16.0
+        Action selection precision -- the inverse temperature of the softmax that is used to scale the 
+        policy posterior before sampling. This is only used if ``action_selection`` argument is "stochastic"
+
+    Returns
+    ----------
+    selected_policy: 1D ``numpy.ndarray``
+        Vector containing the indices of the actions for each control factor
+    """
+
+    num_factors = len(num_controls)
+
+    if action_selection == "deterministic":
+        policy_idx = np.argmax(q_pi)
+    elif action_selection == "stochastic":
+        log_qpi = spm_log_single(q_pi)
+        p_policies = softmax(log_qpi * alpha)
+        policy_idx = utils.sample(p_policies)
+
+    selected_policy = np.zeros(num_factors)
+    for factor_i in range(num_factors):
+        selected_policy[factor_i] = policies[policy_idx][0, factor_i]
+
+    return selected_policy

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -438,7 +438,37 @@ class TestAgent(unittest.TestCase):
         entropy_p_actions2 = -maths.spm_log_single(p_actions2[0]).dot(p_actions2[0])
 
         self.assertGreater(entropy_p_actions2, entropy_p_actions1)
+    
+    def test_agent_with_sampling_mode(self):
+        """
+        Test for passing in `sampling_mode` argument to `agent.Agent()` constructor, which determines whether you sample
+        from posterior marginal over actions ("marginal", default) or posterior over policies ("full")
+        """
 
+        num_obs = [2]
+        num_states = [2]
+        num_controls = [2]
+        A = utils.to_obj_array(np.eye(num_obs[0], num_states[0]))
+        B = utils.construct_controllable_B(num_states, num_controls)
+        C = utils.to_obj_array(np.array([1.01, 1.0]))
+
+        agent = Agent(A=A, B=B, C=C, alpha = 16.0, sampling_mode = "full", action_selection = "stochastic")
+        agent.infer_states(([0]))
+        agent.infer_policies()
+        chosen_action, p_policies = agent._sample_action_test()
+        self.assertEqual(len(p_policies), len(agent.q_pi))
+
+        agent = Agent(A=A, B=B, C=C, alpha = 16.0, sampling_mode = "full", action_selection = "deterministic")
+        agent.infer_states(([0]))
+        agent.infer_policies()
+        chosen_action, p_policies = agent._sample_action_test()
+        self.assertEqual(len(p_policies), len(agent.q_pi))
+
+        agent = Agent(A=A, B=B, C=C, alpha = 16.0, sampling_mode = "marginal", action_selection = "stochastic")
+        agent.infer_states(([0]))
+        agent.infer_policies()
+        chosen_action, p_actions = agent._sample_action_test()
+        self.assertEqual(len(p_actions[0]), num_controls[0])
         
 
 

--- a/test/test_control.py
+++ b/test/test_control.py
@@ -1313,7 +1313,28 @@ class TestControl(unittest.TestCase):
 
         chosen_action = control.sample_action(q_pi, policies, num_controls, action_selection="deterministic")
         self.assertEqual(int(chosen_action[0]), 1)
-    
+
+    def test_sample_policy(self):
+        """
+        Tests the action selection function where policies are sampled directly from posterior over policies `q_pi`
+        """
+
+        num_states = [3, 2]
+        num_controls = [3, 2]
+
+        policies = control.construct_policies(num_states, num_controls, policy_len=3)
+
+        q_pi = utils.norm_dist(np.random.rand(len(policies)))
+        best_policy = policies[np.argmax(q_pi)]
+
+        selected_policy = control.sample_policy(q_pi, policies, num_controls)
+
+        for factor_ii in range(len(num_controls)):
+            self.assertEqual(selected_policy[factor_ii], best_policy[0,factor_ii])
+        
+        selected_policy_stochastic = control.sample_policy(q_pi, policies, num_controls, action_selection="stochastic", alpha = 1.0)
+        self.assertEqual(selected_policy_stochastic.shape, selected_policy.shape)
+        
     def test_update_posterior_policies_withE_vector(self):
         """
         Test update posterior policies in the case that there is a prior over policies


### PR DESCRIPTION
Allows direct sampling from posterior over policies, rather than action marginal.

- New control function in `control.py` called `sample_policy()` as well as private test version called `_sample_policy_test()` that returns the probability distribution over policies as well as the chosen policy.
- New optional argument to `Agent()` constructor `"sampling_mode"` that flags whether you'd like to sample from the posterior over policies or the posterior over actions -- "full" mode or "marginal" mode (default: "marginal").
- Unit tests for all features (both single control.py usage as well as within `Agent()` method

To address Issue #87 