### PR TITLE
Add complex action dependencies to Sparse likelihoods 111

### DIFF
--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -162,10 +162,10 @@ class Agent(object):
         else:
             for f in range(self.num_factors):
                 assert max(B_factor_list[f]) <= (self.num_factors - 1), f"Check factor {f} of B_factor_list - must be consistent with `num_states` and `num_factors`..."
-                factor_dims = tuple([self.num_states[f] for f in B_factor_list[f]])
-                assert self.B[f].shape[1:-1] == factor_dims, f"Check factor {f} of B_factor_list. It must coincide with all-but-final lagging dimensions of B{f}..." 
+                factor_dims = tuple([self.num_states[f]] + [self.num_states[i] for i in B_factor_list[f]])
+                assert self.B[f].shape[:len(factor_dims)] == factor_dims, f"Check factor {f} of B_factor_list. It must coincide with all-but-final lagging dimensions of B{f}..." 
                 if self.pB is not None:
-                    assert self.pB[f].shape[1:-1] == factor_dims, f"Check factor {f} of B_factor_list. It must coincide with all-but-final lagging dimensions of pB{f}..."
+                    assert self.pB[f].shape[:len(factor_dims)] == factor_dims, f"Check factor {f} of B_factor_list. It must coincide with all-but-final lagging dimensions of pB{f}..."
             self.B_factor_list = B_factor_list
         
         # a list storing the control variables each factor is conditioned on
@@ -863,6 +863,7 @@ class Agent(object):
             self.qs,
             qs_prev,
             self.B_factor_list,
+            self.B_factor_control_list,
             self.lr_pB,
             self.factors_to_learn
         )

--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -161,7 +161,8 @@ class Agent(object):
                     assert self.pB[f].shape[1:-1] == factor_dims, f"Please input a `B_factor_list` whose {f}-th indices pick out the hidden state factors that line up with the all-but-final lagging dimensions of pB{f}..." 
         else:
             for f in range(self.num_factors):
-                assert max(B_factor_list[f]) <= (self.num_factors - 1), f"Check factor {f} of B_factor_list - must be consistent with `num_states` and `num_factors`..."
+                if B_factor_list[f] != []:
+                    assert max(B_factor_list[f]) <= (self.num_factors - 1), f"Check factor {f} of B_factor_list - must be consistent with `num_states` and `num_factors`..."
                 factor_dims = tuple([self.num_states[f]] + [self.num_states[i] for i in B_factor_list[f]])
                 assert self.B[f].shape[:len(factor_dims)] == factor_dims, f"Check factor {f} of B_factor_list. It must coincide with all-but-final lagging dimensions of B{f}..." 
                 if self.pB is not None:

--- a/pymdp/control.py
+++ b/pymdp/control.py
@@ -543,7 +543,7 @@ def get_expected_states_interactions(qs, B, B_factor_list, B_factor_control_list
         for factor in range(n_factors):
             factor_idx = B_factor_list[factor] # list of the hidden state indices that the dynamics of `qs[control_factor]` depend on
             action_idx = policy[t, B_factor_control_list[factor]] # list of the action indices that the dynamics of `qs[control_factor]` depend on
-            B_a = utils.condition_B_on_action(B[factor], action_idx)
+            B_a = B[factor][..., *action_idx.astype(int)]
             qs_pi[t+1][factor] = spm_dot(B_a, qs_pi[t][factor_idx])
     return qs_pi[1:]
  
@@ -911,8 +911,8 @@ def calc_pB_info_gain_interactions(pB, qs_pi, qs_prev, B_factor_list, B_factor_c
         policy_t = policy[t, :]
         for factor in range(num_factors):
             action_idx = policy_t[B_factor_control_list[factor]]
-            wB_a = utils.condition_B_on_action(wB[factor], action_idx)
-            pB_a = utils.condition_B_on_action(pB[factor], action_idx)
+            wB_a = wB[factor][..., *action_idx.astype(int)]
+            pB_a = pB[factor][..., *action_idx.astype(int)]
             wB_factor_t = wB_a * (pB_a > 0).astype("float")
             f_idx = B_factor_list[factor]
             pB_infogain -= qs_pi[t][factor].dot(spm_dot(wB_factor_t, previous_qs[f_idx]))

--- a/pymdp/maths.py
+++ b/pymdp/maths.py
@@ -222,7 +222,7 @@ def dot_likelihood(A,obs):
     s[0] = obs.shape[0]
     X = A * obs.reshape(tuple(s))
     X = np.sum(X, axis=0, keepdims=True)
-    LL = np.squeeze(X)
+    LL = np.squeeze(X, axis=0)
 
     # check to see if `LL` is a scalar
     if np.prod(LL.shape) <= 1.0:

--- a/pymdp/utils.py
+++ b/pymdp/utils.py
@@ -106,21 +106,28 @@ def random_A_matrix(num_obs, num_states, A_factor_list=None):
         A[modality] = norm_dist(modality_dist)
     return A
 
-def random_B_matrix(num_states, num_controls, B_factor_list=None):
+def random_B_matrix(num_states, num_controls, B_factor_list=None, B_factor_control_list=None):
     if type(num_states) is int:
         num_states = [num_states]
     if type(num_controls) is int:
         num_controls = [num_controls]
     num_factors = len(num_states)
-    assert len(num_controls) == len(num_states)
 
     if B_factor_list is None:
         B_factor_list = [[f] for f in range(num_factors)]
 
+    if B_factor_control_list is None:
+        assert len(num_controls) == len(num_states)
+        B_factor_control_list = [[f] for f in range(num_factors)]
+    else:
+        unique_controls = list(set(sum(B_factor_control_list, [])))        
+        assert unique_controls == list(range(len(num_controls)))
+
     B = obj_array(num_factors)
     for factor in range(num_factors):
         lagging_shape = [ns for i, ns in enumerate(num_states) if i in B_factor_list[factor]]
-        factor_shape = [num_states[factor]] + lagging_shape + [num_controls[factor]]
+        control_shape = [num_controls[i] for i in B_factor_control_list[factor]]
+        factor_shape = [num_states[factor]] + lagging_shape + control_shape
         # factor_shape = (num_states[factor], num_states[factor], num_controls[factor])
         factor_dist = np.random.rand(*factor_shape)
         B[factor] = norm_dist(factor_dist)
@@ -615,6 +622,15 @@ def convert_B_stubs_to_ndarray(B_stubs, model_labels):
 #                 belief_array[policy_i, :, timestep] = qx[policy_i][timestep][0]
     
 #     return belief_array
+
+def condition_B_on_action(B, action_idx):
+    """
+    This function conditions the B matrix on all action variables.
+    """
+    B_a = B.copy()
+    for a in action_idx[::-1]:
+        B_a = B_a[..., int(a)]
+    return B_a
 
 def build_xn_vn_array(xn):
 

--- a/pymdp/utils.py
+++ b/pymdp/utils.py
@@ -623,15 +623,6 @@ def convert_B_stubs_to_ndarray(B_stubs, model_labels):
     
 #     return belief_array
 
-def condition_B_on_action(B, action_idx):
-    """
-    This function conditions the B matrix on all action variables.
-    """
-    B_a = B.copy()
-    for a in action_idx[::-1]:
-        B_a = B_a[..., int(a)]
-    return B_a
-
 def build_xn_vn_array(xn):
 
     """

--- a/pymdp/utils.py
+++ b/pymdp/utils.py
@@ -126,9 +126,8 @@ def random_B_matrix(num_states, num_controls, B_factor_list=None, B_factor_contr
     B = obj_array(num_factors)
     for factor in range(num_factors):
         lagging_shape = [ns for i, ns in enumerate(num_states) if i in B_factor_list[factor]]
-        control_shape = [num_controls[i] for i in B_factor_control_list[factor]]
+        control_shape = [na for i, na in enumerate(num_controls) if i in B_factor_control_list[factor]]
         factor_shape = [num_states[factor]] + lagging_shape + control_shape
-        # factor_shape = (num_states[factor], num_states[factor], num_controls[factor])
         factor_dist = np.random.rand(*factor_shape)
         B[factor] = norm_dist(factor_dist)
     return B
@@ -258,7 +257,7 @@ def is_normalized(dist):
     if is_obj_array(dist):
         normed_arrays = []
         for i, arr in enumerate(dist):
-            column_sums = arr.sum(axis=0)
+            column_sums = arr.sum(axis=0).astype(float)
             normed_arrays.append(np.allclose(column_sums, np.ones_like(column_sums)))
         out = all(normed_arrays)
     else:

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -802,13 +802,81 @@ class TestAgent(unittest.TestCase):
             agent.update_A(obs_seq[t])
             if t > 0:
                 agent.update_B(qs_prev = agent.qs_hist[-2]) # need to have `save_belief_hist=True` for this to work
+    
+    def test_actinfloop_factorized_multi_action(self):
+        """
+        Test that an instance of the `Agent` class can be initialized and run
+        with the fully-factorized multi-action generative model functions (including policy inference)
+        """
 
+        num_obs = [5, 4, 4]
+        num_states = [2, 3, 5]
+        num_controls = [2, 3, 2]
 
+        A_factor_list = [[0], [0, 1], [0, 1, 2]]
+        B_factor_list = [[0], [0, 1], [1, 2]]
+        B_factor_control_list = [[0], [0, 1], [0, 2]]
+        A = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_factor_list)
+        B = utils.random_B_matrix(num_states, num_controls, B_factor_list=B_factor_list, B_factor_control_list=B_factor_control_list)
+
+        agent = Agent(
+            A=A, 
+            B=B, 
+            A_factor_list=A_factor_list, 
+            B_factor_list=B_factor_list, 
+            B_factor_control_list=B_factor_control_list, 
+            num_controls=num_controls,
+            inference_algo="VANILLA"
+        )
+
+        obs_seq = []
+        for t in range(5):
+            obs_seq.append([np.random.randint(obs_dim) for obs_dim in num_obs])
         
-
-
+        for t in range(5):
+            qs_out = agent.infer_states(obs_seq[t])
+            agent.infer_policies()
+            agent.sample_action()
         
+        """ Test with pA and pB learning & information gain """
 
+        num_obs = [5, 4, 4]
+        num_states = [2, 3, 5]
+        num_controls = [2, 3, 2]
+
+        A_factor_list = [[0], [0, 1], [0, 1, 2]]
+        B_factor_list = [[0], [0, 1], [1, 2]]
+        B_factor_control_list = [[0], [0, 1], [0, 2]]
+        A = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_factor_list)
+        B = utils.random_B_matrix(num_states, num_controls, B_factor_list=B_factor_list, B_factor_control_list=B_factor_control_list)
+        pA = utils.dirichlet_like(A)
+        pB = utils.dirichlet_like(B)
+
+        agent = Agent(
+            A=A, 
+            pA=pA, 
+            B=B, 
+            pB=pB, 
+            save_belief_hist=True, 
+            use_param_info_gain=True, 
+            A_factor_list=A_factor_list, 
+            B_factor_list=B_factor_list, 
+            B_factor_control_list=B_factor_control_list,
+            num_controls=num_controls,
+            inference_algo="VANILLA"
+        )
+
+        obs_seq = []
+        for t in range(5):
+            obs_seq.append([np.random.randint(obs_dim) for obs_dim in num_obs])
+        
+        for t in range(5):
+            qs_out = agent.infer_states(obs_seq[t])
+            agent.infer_policies()
+            agent.sample_action()
+            agent.update_A(obs_seq[t])
+            if t > 0:
+                agent.update_B(qs_prev = agent.qs_hist[-2]) # need to have `save_belief_hist=True` for this to work
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -878,6 +878,83 @@ class TestAgent(unittest.TestCase):
             if t > 0:
                 agent.update_B(qs_prev = agent.qs_hist[-2]) # need to have `save_belief_hist=True` for this to work
 
+    def test_actinfloop_factorized_multi_action_sparse(self):
+        """
+        Test that an instance of the `Agent` class can be initialized and run
+        with the fully-factorized multi-action generative model functions (including policy inference)
+        some states have no action dependencies
+        made a state to have 1 element to trigger dot_likelihood np.squeeze error
+        """
+
+        num_obs = [5, 4, 4]
+        num_states = [2, 3, 1]
+        num_controls = [2, 3, 2]
+
+        A_factor_list = [[0], [0, 1], [0, 1, 2]]
+        B_factor_list = [[0], [0, 1], [1, 2]]
+        B_factor_control_list = [[], [0, 1], [0, 2]]
+        A = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_factor_list)
+        B = utils.random_B_matrix(num_states, num_controls, B_factor_list=B_factor_list, B_factor_control_list=B_factor_control_list)
+
+        agent = Agent(
+            A=A, 
+            B=B, 
+            A_factor_list=A_factor_list, 
+            B_factor_list=B_factor_list, 
+            B_factor_control_list=B_factor_control_list, 
+            num_controls=num_controls,
+            inference_algo="VANILLA"
+        )
+
+        obs_seq = []
+        for t in range(5):
+            obs_seq.append([np.random.randint(obs_dim) for obs_dim in num_obs])
+        
+        for t in range(5):
+            qs_out = agent.infer_states(obs_seq[t])
+            agent.infer_policies()
+            agent.sample_action()
+        
+        """ Test with pA and pB learning & information gain """
+
+        num_obs = [5, 4, 4]
+        num_states = [2, 3, 5]
+        num_controls = [2, 3, 2]
+
+        A_factor_list = [[0], [0, 1], [0, 1, 2]]
+        B_factor_list = [[0], [0, 1], [1, 2]]
+        B_factor_control_list = [[], [0, 1], [0, 2]]
+        A = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_factor_list)
+        B = utils.random_B_matrix(num_states, num_controls, B_factor_list=B_factor_list, B_factor_control_list=B_factor_control_list)
+        pA = utils.dirichlet_like(A)
+        pB = utils.dirichlet_like(B)
+
+        agent = Agent(
+            A=A, 
+            pA=pA, 
+            B=B, 
+            pB=pB, 
+            save_belief_hist=True, 
+            use_param_info_gain=True, 
+            A_factor_list=A_factor_list, 
+            B_factor_list=B_factor_list, 
+            B_factor_control_list=B_factor_control_list,
+            num_controls=num_controls,
+            inference_algo="VANILLA"
+        )
+
+        obs_seq = []
+        for t in range(5):
+            obs_seq.append([np.random.randint(obs_dim) for obs_dim in num_obs])
+        
+        for t in range(5):
+            qs_out = agent.infer_states(obs_seq[t])
+            agent.infer_policies()
+            agent.sample_action()
+            agent.update_A(obs_seq[t])
+            if t > 0:
+                agent.update_B(qs_prev = agent.qs_hist[-2]) # need to have `save_belief_hist=True` for this to work
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
Introduced a new `B_factor_control_list` variable so that the user can specify the control variables each transition factor depends on using a list similar to the `B_factor_list` introduced to specify state dependencies.

* Made edits to `utils, control, learning, agent`
* The shape of B matrices is now defined as: `[state_dim] + lagging_state_dims + control_dims`. Conditioning on actions can be done easily with `B[..., *relevant_action_idx]`
* Added checks/assertions in `agent.__init__`
* Added relevant tests. Fixed a bunch of failed tests due to using `!=` rather than `is not` in `agent.__init__`. 
* All tests passed except for those in `test_mmp.py` and `test_SPM_validation.py`