### PR TITLE
Feature/learning unit tests

### DIFF
--- a/pymdp/jax/learning.py
+++ b/pymdp/jax/learning.py
@@ -86,7 +86,7 @@ def update_state_transition_dirichlet(pB, joint_beliefs, actions, *, num_control
     lr:
         learning rate: scale of the Dirichlet pseudo-count update
     factors_to_update:
-        A list of the modalities for which to perform the update
+        A list of the modalities for which to perform the update. Default updates all factors
 
     Returns
     ----------

--- a/pymdp/jax/learning.py
+++ b/pymdp/jax/learning.py
@@ -2,14 +2,13 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=no-member
 
-import numpy as np
-from .maths import multidimensional_outer
+from .maths import multidimensional_outer, dirichlet_expected_value
 from jax.tree_util import tree_map
-from jax import vmap
-import jax.numpy as jnp
+from jax import vmap, nn
+
 
 def update_obs_likelihood_dirichlet_m(pA_m, obs_m, qs, dependencies_m, lr=1.0):
-    """ JAX version of ``pymdp.learning.update_obs_likelihood_dirichlet_m`` """
+    """JAX version of ``pymdp.learning.update_obs_likelihood_dirichlet_m``"""
     # pA_m - parameters of the dirichlet from the prior
     # pA_m.shape = (no_m x num_states[k] x num_states[j] x ... x num_states[n]) where (k, j, n) are indices of the hidden state factors that are parents of modality m
 
@@ -26,18 +25,30 @@ def update_obs_likelihood_dirichlet_m(pA_m, obs_m, qs, dependencies_m, lr=1.0):
 
     dfda = vmap(multidimensional_outer)([obs_m] + relevant_factors).sum(axis=0)
 
-    return pA_m + lr * dfda
-    
-def update_obs_likelihood_dirichlet(pA, obs, qs, A_dependencies, lr=1.0):
-    """ JAX version of ``pymdp.learning.update_obs_likelihood_dirichlet`` """
+    new_pA_m = pA_m + lr * dfda
 
-    update_A_fn = lambda pA_m, obs_m, dependencies_m: update_obs_likelihood_dirichlet_m(pA_m, obs_m, qs, dependencies_m, lr=lr)
-    qA = tree_map(update_A_fn, pA, obs, A_dependencies)
+    return new_pA_m, dirichlet_expected_value(new_pA_m)
 
-    return qA
 
-def update_state_likelihood_dirichlet_f(pB_f, actions_f, current_qs, qs_seq, dependencies_f, lr=1.0):
-    """ JAX version of ``pymdp.learning.update_state_likelihood_dirichlet_f`` """
+def update_obs_likelihood_dirichlet(pA, obs, qs, *, A_dependencies, onehot_obs, num_obs, lr):
+    """JAX version of ``pymdp.learning.update_obs_likelihood_dirichlet``"""
+
+    obs_m = lambda o, dim: nn.one_hot(o, dim) if not onehot_obs else o
+    update_A_fn = lambda pA_m, o_m, dim, dependencies_m: update_obs_likelihood_dirichlet_m(
+        pA_m, obs_m(o_m, dim), qs, dependencies_m, lr=lr
+    )
+    result = tree_map(update_A_fn, pA, obs, num_obs, A_dependencies)
+    qA = []
+    E_qA = []
+    for r in result:
+        qA.append(r[0])
+        E_qA.append(r[1])
+
+    return qA, E_qA
+
+
+def update_state_transition_dirichlet_f(pB_f, actions_f, joint_qs_f, lr=1.0):
+    """JAX version of ``pymdp.learning.update_state_likelihood_dirichlet_f``"""
     # pB_f - parameters of the dirichlet from the prior
     # pB_f.shape = (num_states[f] x num_states[f] x num_actions[f]) where f is the index of the hidden state factor
 
@@ -50,265 +61,279 @@ def update_state_likelihood_dirichlet_f(pB_f, actions_f, current_qs, qs_seq, dep
     # \otimes is a multidimensional outer product, not just a outer product of two vectors
     # \kappa is an optional learning rate
 
-    past_qs = tree_map(lambda f_idx: qs_seq[f_idx][:-1], dependencies_f)
-    dfdb = vmap(multidimensional_outer)([current_qs[1:]] + past_qs + [actions_f]).sum(axis=0)
+    dfdb = vmap(multidimensional_outer)(joint_qs_f + [actions_f]).sum(axis=0)
     qB_f = pB_f + lr * dfdb
 
-    return qB_f
-
-def update_state_likelihood_dirichlet(pB, beliefs, actions_onehot, B_dependencies, lr=1.0):
-
-    update_B_f_fn = lambda pB_f, action_f, qs_f, dependencies_f: update_state_likelihood_dirichlet_f(pB_f, action_f, qs_f, beliefs, dependencies_f, lr=lr)    
-    qB = tree_map(update_B_f_fn, pB, actions_onehot, beliefs, B_dependencies)
-
-    return qB
-    
-
-def update_state_prior_dirichlet(
-    pD, qs, lr=1.0, factors="all"
-):
-    """
-    Update Dirichlet parameters of the initial hidden state distribution 
-    (prior beliefs about hidden states at the beginning of the inference window).
-
-    Parameters
-    -----------
-    pD: ``numpy.ndarray`` of dtype object
-        Prior Dirichlet parameters over initial hidden state prior (same shape as ``qs``)
-    qs: 1D ``numpy.ndarray`` or ``numpy.ndarray`` of dtype object
-        Marginal posterior beliefs over hidden states at current timepoint
-    lr: float, default ``1.0``
-        Learning rate, scale of the Dirichlet pseudo-count update.
-    factors: ``list``, default "all"
-        Indices (ranging from 0 to ``n_factors - 1``) of the hidden state factors to include 
-        in learning. Defaults to "all", meaning that factor-specific sub-vectors of ``pD``
-        are all updated using the corresponding hidden state distributions.
-    
-    Returns
-    -----------
-    qD: ``numpy.ndarray`` of dtype object
-        Posterior Dirichlet parameters over initial hidden state prior (same shape as ``qs``), after having updated it with state beliefs.
-    """
-
-    num_factors = len(pD)
-
-    qD = copy.deepcopy(pD)
-   
-    if factors == "all":
-        factors = list(range(num_factors))
-
-    for factor in factors:
-        idx = pD[factor] > 0 # only update those state level indices that have some prior probability
-        qD[factor][idx] += (lr * qs[factor][idx])
-       
-    return qD
-
-def _prune_prior(prior, levels_to_remove, dirichlet = False):
-    """
-    Function for pruning a prior Categorical distribution (e.g. C, D)
-
-    Parameters
-    -----------
-    prior: 1D ``numpy.ndarray`` or ``numpy.ndarray`` of dtype object
-        The vector(s) containing the priors over hidden states of a generative model, e.g. the prior over hidden states (``D`` vector). 
-    levels_to_remove: ``list`` of ``int``, ``list`` of ``list``
-        A ``list`` of the levels (indices of the support) to remove. If the prior in question has multiple hidden state factors / multiple observation modalities, 
-        then this will be a ``list`` of ``list``, where each sub-list within ``levels_to_remove`` will contain the levels to prune for a particular hidden state factor or modality 
-    dirichlet: ``Bool``, default ``False``
-        A Boolean flag indicating whether the input vector(s) is/are a Dirichlet distribution, and therefore should not be normalized at the end. 
-        @TODO: Instead, the dirichlet parameters from the pruned levels should somehow be re-distributed among the remaining levels
-
-    Returns
-    -----------
-    reduced_prior: 1D ``numpy.ndarray`` or ``numpy.ndarray`` of dtype object
-        The prior vector(s), after pruning, that lacks the hidden state or modality levels indexed by ``levels_to_remove``
-    """
-
-    if utils.is_obj_array(prior): # in case of multiple hidden state factors
-
-        assert all([type(levels) == list for levels in levels_to_remove])
-
-        num_factors = len(prior)
-
-        reduced_prior = utils.obj_array(num_factors)
-
-        factors_to_remove = []
-        for f, s_i in enumerate(prior): # loop over factors (or modalities)
-            
-            ns = len(s_i)
-            levels_to_keep = list(set(range(ns)) - set(levels_to_remove[f]))
-            if len(levels_to_keep) == 0:
-                print(f'Warning... removing ALL levels of factor {f} - i.e. the whole hidden state factor is being removed\n')
-                factors_to_remove.append(f)
-            else:
-                if not dirichlet:
-                    reduced_prior[f] = utils.norm_dist(s_i[levels_to_keep])
-                else:
-                    raise(NotImplementedError("Need to figure out how to re-distribute concentration parameters from pruned levels, across remaining levels"))
+    return qB_f, dirichlet_expected_value(qB_f)
 
 
-        if len(factors_to_remove) > 0:
-            factors_to_keep = list(set(range(num_factors)) - set(factors_to_remove))
-            reduced_prior = reduced_prior[factors_to_keep]
+def update_state_transition_dirichlet(pB, joint_beliefs, actions, *, num_controls, lr, B_dependencies=None):
 
-    else: # in case of one hidden state factor
+    nf = len(pB)
+    if B_dependencies is None:
+        B_dependencies = list(range(nf))
 
-        assert all([type(level_i) == int for level_i in levels_to_remove])
+    actions_onehot_fn = lambda f, dim: nn.one_hot(actions[..., f], dim, axis=-1)
 
-        ns = len(prior)
-        levels_to_keep = list(set(range(ns)) - set(levels_to_remove))
+    update_B_f_fn = lambda pB_f, joint_qs_f, f, na: update_state_transition_dirichlet_f(
+        pB_f, actions_onehot_fn(f, na), joint_qs_f, lr=lr
+    )
+    result = tree_map(update_B_f_fn, pB, joint_beliefs, B_dependencies, num_controls)
 
-        if not dirichlet:
-            reduced_prior = utils.norm_dist(prior[levels_to_keep])
-        else:
-            raise(NotImplementedError("Need to figure out how to re-distribute concentration parameters from pruned levels, across remaining levels"))
+    qB = []
+    E_qB = []
+    for r in result:
+        qB.append(r[0])
+        E_qB.append(r[1])
 
-    return reduced_prior
+    return qB, E_qB
 
-def _prune_A(A, obs_levels_to_prune, state_levels_to_prune, dirichlet = False):
-    """
-    Function for pruning a observation likelihood model (with potentially multiple hidden state factors)
-    :meta private:
-    Parameters
-    -----------
-    A: ``numpy.ndarray`` with ``ndim >= 2``, or ``numpy.ndarray`` of dtype object
-        Sensory likelihood mapping or 'observation model', mapping from hidden states to observations. Each element ``A[m]`` of
-        stores an ``numpy.ndarray`` multidimensional array for observation modality ``m``, whose entries ``A[m][i, j, k, ...]`` store 
-        the probability of observation level ``i`` given hidden state levels ``j, k, ...``
-    obs_levels_to_prune: ``list`` of int or ``list`` of ``list``: 
-        A ``list`` of the observation levels to remove. If the likelihood in question has multiple observation modalities, 
-        then this will be a ``list`` of ``list``, where each sub-list within ``obs_levels_to_prune`` will contain the observation levels 
-        to remove for a particular observation modality 
-    state_levels_to_prune: ``list`` of ``int``
-        A ``list`` of the hidden state levels to remove (this will be the same across modalities)
-    dirichlet: ``Bool``, default ``False``
-        A Boolean flag indicating whether the input array(s) is/are a Dirichlet distribution, and therefore should not be normalized at the end. 
-        @TODO: Instead, the dirichlet parameters from the pruned columns should somehow be re-distributed among the remaining columns
 
-    Returns
-    -----------
-    reduced_A: ``numpy.ndarray`` with ndim >= 2, or ``numpy.ndarray ``of dtype object
-        The observation model, after pruning, which lacks the observation or hidden state levels given by the arguments ``obs_levels_to_prune`` and ``state_levels_to_prune``
-    """
+# def update_state_prior_dirichlet(
+#     pD, qs, lr=1.0, factors="all"
+# ):
+#     """
+#     Update Dirichlet parameters of the initial hidden state distribution
+#     (prior beliefs about hidden states at the beginning of the inference window).
 
-    columns_to_keep_list = []
-    if utils.is_obj_array(A):
-        num_states = A[0].shape[1:]
-        for f, ns in enumerate(num_states):
-            indices_f = np.array( list(set(range(ns)) - set(state_levels_to_prune[f])), dtype = np.intp)
-            columns_to_keep_list.append(indices_f)
-    else:
-        num_states = A.shape[1]
-        indices = np.array( list(set(range(num_states)) - set(state_levels_to_prune)), dtype = np.intp )
-        columns_to_keep_list.append(indices)
+#     Parameters
+#     -----------
+#     pD: ``numpy.ndarray`` of dtype object
+#         Prior Dirichlet parameters over initial hidden state prior (same shape as ``qs``)
+#     qs: 1D ``numpy.ndarray`` or ``numpy.ndarray`` of dtype object
+#         Marginal posterior beliefs over hidden states at current timepoint
+#     lr: float, default ``1.0``
+#         Learning rate, scale of the Dirichlet pseudo-count update.
+#     factors: ``list``, default "all"
+#         Indices (ranging from 0 to ``n_factors - 1``) of the hidden state factors to include
+#         in learning. Defaults to "all", meaning that factor-specific sub-vectors of ``pD``
+#         are all updated using the corresponding hidden state distributions.
 
-    if utils.is_obj_array(A): # in case of multiple observation modality
+#     Returns
+#     -----------
+#     qD: ``numpy.ndarray`` of dtype object
+#         Posterior Dirichlet parameters over initial hidden state prior (same shape as ``qs``), after having updated it with state beliefs.
+#     """
 
-        assert all([type(o_m_levels) == list for o_m_levels in obs_levels_to_prune])
+#     num_factors = len(pD)
 
-        num_modalities = len(A)
+#     qD = copy.deepcopy(pD)
 
-        reduced_A = utils.obj_array(num_modalities)
-        
-        for m, A_i in enumerate(A): # loop over modalities
-            
-            no = A_i.shape[0]
-            rows_to_keep = np.array(list(set(range(no)) - set(obs_levels_to_prune[m])), dtype = np.intp)
-            
-            reduced_A[m] = A_i[np.ix_(rows_to_keep, *columns_to_keep_list)]
-        if not dirichlet:    
-            reduced_A = utils.norm_dist_obj_arr(reduced_A)
-        else:
-            raise(NotImplementedError("Need to figure out how to re-distribute concentration parameters from pruned rows/columns, across remaining rows/columns"))
-    else: # in case of one observation modality
+#     if factors == "all":
+#         factors = list(range(num_factors))
 
-        assert all([type(o_levels_i) == int for o_levels_i in obs_levels_to_prune])
+#     for factor in factors:
+#         idx = pD[factor] > 0 # only update those state level indices that have some prior probability
+#         qD[factor][idx] += (lr * qs[factor][idx])
 
-        no = A.shape[0]
-        rows_to_keep = np.array(list(set(range(no)) - set(obs_levels_to_prune)), dtype = np.intp)
-            
-        reduced_A = A[np.ix_(rows_to_keep, *columns_to_keep_list)]
+#     return qD
 
-        if not dirichlet:
-            reduced_A = utils.norm_dist(reduced_A)
-        else:
-            raise(NotImplementedError("Need to figure out how to re-distribute concentration parameters from pruned rows/columns, across remaining rows/columns"))
+# def _prune_prior(prior, levels_to_remove, dirichlet = False):
+#     """
+#     Function for pruning a prior Categorical distribution (e.g. C, D)
 
-    return reduced_A
+#     Parameters
+#     -----------
+#     prior: 1D ``numpy.ndarray`` or ``numpy.ndarray`` of dtype object
+#         The vector(s) containing the priors over hidden states of a generative model, e.g. the prior over hidden states (``D`` vector).
+#     levels_to_remove: ``list`` of ``int``, ``list`` of ``list``
+#         A ``list`` of the levels (indices of the support) to remove. If the prior in question has multiple hidden state factors / multiple observation modalities,
+#         then this will be a ``list`` of ``list``, where each sub-list within ``levels_to_remove`` will contain the levels to prune for a particular hidden state factor or modality
+#     dirichlet: ``Bool``, default ``False``
+#         A Boolean flag indicating whether the input vector(s) is/are a Dirichlet distribution, and therefore should not be normalized at the end.
+#         @TODO: Instead, the dirichlet parameters from the pruned levels should somehow be re-distributed among the remaining levels
 
-def _prune_B(B, state_levels_to_prune, action_levels_to_prune, dirichlet = False):
-    """
-    Function for pruning a transition likelihood model (with potentially multiple hidden state factors)
+#     Returns
+#     -----------
+#     reduced_prior: 1D ``numpy.ndarray`` or ``numpy.ndarray`` of dtype object
+#         The prior vector(s), after pruning, that lacks the hidden state or modality levels indexed by ``levels_to_remove``
+#     """
 
-    Parameters
-    -----------
-    B: ``numpy.ndarray`` of ``ndim == 3`` or ``numpy.ndarray`` of dtype object
-        Dynamics likelihood mapping or 'transition model', mapping from hidden states at `t` to hidden states at `t+1`, given some control state `u`.
-        Each element B[f] of this object array stores a 3-D tensor for hidden state factor `f`, whose entries `B[f][s, v, u] store the probability
-        of hidden state level `s` at the current time, given hidden state level `v` and action `u` at the previous time.
-    state_levels_to_prune: ``list`` of ``int`` or ``list`` of ``list`` 
-        A ``list`` of the state levels to remove. If the likelihood in question has multiple hidden state factors, 
-        then this will be a ``list`` of ``list``, where each sub-list within ``state_levels_to_prune`` will contain the state levels 
-        to remove for a particular hidden state factor 
-    action_levels_to_prune: ``list`` of ``int`` or ``list`` of ``list`` 
-        A ``list`` of the control state or action levels to remove. If the likelihood in question has multiple control state factors, 
-        then this will be a ``list`` of ``list``, where each sub-list within ``action_levels_to_prune`` will contain the control state levels 
-        to remove for a particular control state factor 
-    dirichlet: ``Bool``, default ``False``
-        A Boolean flag indicating whether the input array(s) is/are a Dirichlet distribution, and therefore should not be normalized at the end. 
-        @TODO: Instead, the dirichlet parameters from the pruned rows/columns should somehow be re-distributed among the remaining rows/columns
+#     if utils.is_obj_array(prior): # in case of multiple hidden state factors
 
-    Returns
-    -----------
-    reduced_B: ``numpy.ndarray`` of `ndim == 3` or ``numpy.ndarray`` of dtype object
-        The transition model, after pruning, which lacks the hidden state levels/action levels given by the arguments ``state_levels_to_prune`` and ``action_levels_to_prune``
-    """
+#         assert all([type(levels) == list for levels in levels_to_remove])
 
-    slices_to_keep_list = []
+#         num_factors = len(prior)
 
-    if utils.is_obj_array(B):
+#         reduced_prior = utils.obj_array(num_factors)
 
-        num_controls = [B_arr.shape[2] for _, B_arr in enumerate(B)]
+#         factors_to_remove = []
+#         for f, s_i in enumerate(prior): # loop over factors (or modalities)
 
-        for c, nc in enumerate(num_controls):
-            indices_c = np.array( list(set(range(nc)) - set(action_levels_to_prune[c])), dtype = np.intp)
-            slices_to_keep_list.append(indices_c)
-    else:
-        num_controls = B.shape[2]
-        slices_to_keep = np.array( list(set(range(num_controls)) - set(action_levels_to_prune)), dtype = np.intp )
+#             ns = len(s_i)
+#             levels_to_keep = list(set(range(ns)) - set(levels_to_remove[f]))
+#             if len(levels_to_keep) == 0:
+#                 print(f'Warning... removing ALL levels of factor {f} - i.e. the whole hidden state factor is being removed\n')
+#                 factors_to_remove.append(f)
+#             else:
+#                 if not dirichlet:
+#                     reduced_prior[f] = utils.norm_dist(s_i[levels_to_keep])
+#                 else:
+#                     raise(NotImplementedError("Need to figure out how to re-distribute concentration parameters from pruned levels, across remaining levels"))
 
-    if utils.is_obj_array(B): # in case of multiple hidden state factors
 
-        assert all([type(ns_f_levels) == list for ns_f_levels in state_levels_to_prune])
+#         if len(factors_to_remove) > 0:
+#             factors_to_keep = list(set(range(num_factors)) - set(factors_to_remove))
+#             reduced_prior = reduced_prior[factors_to_keep]
 
-        num_factors = len(B)
+#     else: # in case of one hidden state factor
 
-        reduced_B = utils.obj_array(num_factors)
-        
-        for f, B_f in enumerate(B): # loop over modalities
-            
-            ns = B_f.shape[0]
-            states_to_keep = np.array(list(set(range(ns)) - set(state_levels_to_prune[f])), dtype = np.intp)
-            
-            reduced_B[f] = B_f[np.ix_(states_to_keep, states_to_keep, slices_to_keep_list[f])]
+#         assert all([type(level_i) == int for level_i in levels_to_remove])
 
-        if not dirichlet:    
-            reduced_B = utils.norm_dist_obj_arr(reduced_B)
-        else:
-            raise(NotImplementedError("Need to figure out how to re-distribute concentration parameters from pruned rows/columns, across remaining rows/columns"))
+#         ns = len(prior)
+#         levels_to_keep = list(set(range(ns)) - set(levels_to_remove))
 
-    else: # in case of one hidden state factor
+#         if not dirichlet:
+#             reduced_prior = utils.norm_dist(prior[levels_to_keep])
+#         else:
+#             raise(NotImplementedError("Need to figure out how to re-distribute concentration parameters from pruned levels, across remaining levels"))
 
-        assert all([type(state_level_i) == int for state_level_i in state_levels_to_prune])
+#     return reduced_prior
 
-        ns = B.shape[0]
-        states_to_keep = np.array(list(set(range(ns)) - set(state_levels_to_prune)), dtype = np.intp)
-            
-        reduced_B = B[np.ix_(states_to_keep, states_to_keep, slices_to_keep)]
+# def _prune_A(A, obs_levels_to_prune, state_levels_to_prune, dirichlet = False):
+#     """
+#     Function for pruning a observation likelihood model (with potentially multiple hidden state factors)
+#     :meta private:
+#     Parameters
+#     -----------
+#     A: ``numpy.ndarray`` with ``ndim >= 2``, or ``numpy.ndarray`` of dtype object
+#         Sensory likelihood mapping or 'observation model', mapping from hidden states to observations. Each element ``A[m]`` of
+#         stores an ``numpy.ndarray`` multidimensional array for observation modality ``m``, whose entries ``A[m][i, j, k, ...]`` store
+#         the probability of observation level ``i`` given hidden state levels ``j, k, ...``
+#     obs_levels_to_prune: ``list`` of int or ``list`` of ``list``:
+#         A ``list`` of the observation levels to remove. If the likelihood in question has multiple observation modalities,
+#         then this will be a ``list`` of ``list``, where each sub-list within ``obs_levels_to_prune`` will contain the observation levels
+#         to remove for a particular observation modality
+#     state_levels_to_prune: ``list`` of ``int``
+#         A ``list`` of the hidden state levels to remove (this will be the same across modalities)
+#     dirichlet: ``Bool``, default ``False``
+#         A Boolean flag indicating whether the input array(s) is/are a Dirichlet distribution, and therefore should not be normalized at the end.
+#         @TODO: Instead, the dirichlet parameters from the pruned columns should somehow be re-distributed among the remaining columns
 
-        if not dirichlet:
-            reduced_B = utils.norm_dist(reduced_B)
-        else:
-            raise(NotImplementedError("Need to figure out how to re-distribute concentration parameters from pruned rows/columns, across remaining rows/columns"))
+#     Returns
+#     -----------
+#     reduced_A: ``numpy.ndarray`` with ndim >= 2, or ``numpy.ndarray ``of dtype object
+#         The observation model, after pruning, which lacks the observation or hidden state levels given by the arguments ``obs_levels_to_prune`` and ``state_levels_to_prune``
+#     """
 
-    return reduced_B
+#     columns_to_keep_list = []
+#     if utils.is_obj_array(A):
+#         num_states = A[0].shape[1:]
+#         for f, ns in enumerate(num_states):
+#             indices_f = np.array( list(set(range(ns)) - set(state_levels_to_prune[f])), dtype = np.intp)
+#             columns_to_keep_list.append(indices_f)
+#     else:
+#         num_states = A.shape[1]
+#         indices = np.array( list(set(range(num_states)) - set(state_levels_to_prune)), dtype = np.intp )
+#         columns_to_keep_list.append(indices)
+
+#     if utils.is_obj_array(A): # in case of multiple observation modality
+
+#         assert all([type(o_m_levels) == list for o_m_levels in obs_levels_to_prune])
+
+#         num_modalities = len(A)
+
+#         reduced_A = utils.obj_array(num_modalities)
+
+#         for m, A_i in enumerate(A): # loop over modalities
+
+#             no = A_i.shape[0]
+#             rows_to_keep = np.array(list(set(range(no)) - set(obs_levels_to_prune[m])), dtype = np.intp)
+
+#             reduced_A[m] = A_i[np.ix_(rows_to_keep, *columns_to_keep_list)]
+#         if not dirichlet:
+#             reduced_A = utils.norm_dist_obj_arr(reduced_A)
+#         else:
+#             raise(NotImplementedError("Need to figure out how to re-distribute concentration parameters from pruned rows/columns, across remaining rows/columns"))
+#     else: # in case of one observation modality
+
+#         assert all([type(o_levels_i) == int for o_levels_i in obs_levels_to_prune])
+
+#         no = A.shape[0]
+#         rows_to_keep = np.array(list(set(range(no)) - set(obs_levels_to_prune)), dtype = np.intp)
+
+#         reduced_A = A[np.ix_(rows_to_keep, *columns_to_keep_list)]
+
+#         if not dirichlet:
+#             reduced_A = utils.norm_dist(reduced_A)
+#         else:
+#             raise(NotImplementedError("Need to figure out how to re-distribute concentration parameters from pruned rows/columns, across remaining rows/columns"))
+
+#     return reduced_A
+
+# def _prune_B(B, state_levels_to_prune, action_levels_to_prune, dirichlet = False):
+#     """
+#     Function for pruning a transition likelihood model (with potentially multiple hidden state factors)
+
+#     Parameters
+#     -----------
+#     B: ``numpy.ndarray`` of ``ndim == 3`` or ``numpy.ndarray`` of dtype object
+#         Dynamics likelihood mapping or 'transition model', mapping from hidden states at `t` to hidden states at `t+1`, given some control state `u`.
+#         Each element B[f] of this object array stores a 3-D tensor for hidden state factor `f`, whose entries `B[f][s, v, u] store the probability
+#         of hidden state level `s` at the current time, given hidden state level `v` and action `u` at the previous time.
+#     state_levels_to_prune: ``list`` of ``int`` or ``list`` of ``list``
+#         A ``list`` of the state levels to remove. If the likelihood in question has multiple hidden state factors,
+#         then this will be a ``list`` of ``list``, where each sub-list within ``state_levels_to_prune`` will contain the state levels
+#         to remove for a particular hidden state factor
+#     action_levels_to_prune: ``list`` of ``int`` or ``list`` of ``list``
+#         A ``list`` of the control state or action levels to remove. If the likelihood in question has multiple control state factors,
+#         then this will be a ``list`` of ``list``, where each sub-list within ``action_levels_to_prune`` will contain the control state levels
+#         to remove for a particular control state factor
+#     dirichlet: ``Bool``, default ``False``
+#         A Boolean flag indicating whether the input array(s) is/are a Dirichlet distribution, and therefore should not be normalized at the end.
+#         @TODO: Instead, the dirichlet parameters from the pruned rows/columns should somehow be re-distributed among the remaining rows/columns
+
+#     Returns
+#     -----------
+#     reduced_B: ``numpy.ndarray`` of `ndim == 3` or ``numpy.ndarray`` of dtype object
+#         The transition model, after pruning, which lacks the hidden state levels/action levels given by the arguments ``state_levels_to_prune`` and ``action_levels_to_prune``
+#     """
+
+#     slices_to_keep_list = []
+
+#     if utils.is_obj_array(B):
+
+#         num_controls = [B_arr.shape[2] for _, B_arr in enumerate(B)]
+
+#         for c, nc in enumerate(num_controls):
+#             indices_c = np.array( list(set(range(nc)) - set(action_levels_to_prune[c])), dtype = np.intp)
+#             slices_to_keep_list.append(indices_c)
+#     else:
+#         num_controls = B.shape[2]
+#         slices_to_keep = np.array( list(set(range(num_controls)) - set(action_levels_to_prune)), dtype = np.intp )
+
+#     if utils.is_obj_array(B): # in case of multiple hidden state factors
+
+#         assert all([type(ns_f_levels) == list for ns_f_levels in state_levels_to_prune])
+
+#         num_factors = len(B)
+
+#         reduced_B = utils.obj_array(num_factors)
+
+#         for f, B_f in enumerate(B): # loop over modalities
+
+#             ns = B_f.shape[0]
+#             states_to_keep = np.array(list(set(range(ns)) - set(state_levels_to_prune[f])), dtype = np.intp)
+
+#             reduced_B[f] = B_f[np.ix_(states_to_keep, states_to_keep, slices_to_keep_list[f])]
+
+#         if not dirichlet:
+#             reduced_B = utils.norm_dist_obj_arr(reduced_B)
+#         else:
+#             raise(NotImplementedError("Need to figure out how to re-distribute concentration parameters from pruned rows/columns, across remaining rows/columns"))
+
+#     else: # in case of one hidden state factor
+
+#         assert all([type(state_level_i) == int for state_level_i in state_levels_to_prune])
+
+#         ns = B.shape[0]
+#         states_to_keep = np.array(list(set(range(ns)) - set(state_levels_to_prune)), dtype = np.intp)
+
+#         reduced_B = B[np.ix_(states_to_keep, states_to_keep, slices_to_keep)]
+
+#         if not dirichlet:
+#             reduced_B = utils.norm_dist(reduced_B)
+#         else:
+#             raise(NotImplementedError("Need to figure out how to re-distribute concentration parameters from pruned rows/columns, across remaining rows/columns"))
+
+#     return reduced_B

--- a/test/test_learning_jax.py
+++ b/test/test_learning_jax.py
@@ -354,8 +354,6 @@ class TestLearningJax(unittest.TestCase):
 
         action_jax = jnp.array([action])
 
-        # Selective update of factors is not implemented within the method, and could be performed like this:
-
         pB_updated_jax_factors, _ = update_pB_jax(
             pB_jax, belief_jax, action_jax, num_controls=num_controls, lr=l_rate, factors_to_update=factors_to_update
         )

--- a/test/test_learning_jax.py
+++ b/test/test_learning_jax.py
@@ -11,47 +11,48 @@ import unittest
 import numpy as np
 import jax.numpy as jnp
 import jax.tree_util as jtu
+from jax import nn
 
 from pymdp.learning import update_obs_likelihood_dirichlet as update_pA_numpy
 from pymdp.learning import update_obs_likelihood_dirichlet_factorized as update_pA_numpy_factorized
-from pymdp.jax.learning import update_obs_likelihood_dirichlet as update_pA_jax
 from pymdp import utils, maths
+
+from pymdp.learning import update_state_likelihood_dirichlet as update_pB_numpy
+from pymdp.learning import update_state_likelihood_dirichlet_interactions as update_pB_interactions_numpy
+
+
+# Temporary to make the mapping
+from pymdp.jax.learning import update_state_likelihood_dirichlet as update_pB_jax_old
+
+from pymdp.jax.learning_dimi import update_obs_likelihood_dirichlet as update_pA_jax
+from pymdp.jax.learning_dimi import update_state_transition_dirichlet as update_pB_jax
+
 
 class TestLearningJax(unittest.TestCase):
 
     def test_update_observation_likelihood_fullyconnected(self):
         """
-        Testing JAX-ified version of updating Dirichlet posterior over observation likelihood parameters (qA is posterior, pA is prior, and A is expectation
-        of likelihood wrt to current posterior over A, i.e. $A = E_{Q(A)}[P(o|s,A)]$.
+        Testing JAX-ified version of updating Dirichlet posterior over observation likelihood parameters (qA is
+        posterior, pA is prior, and A is expectation of likelihood wrt to current posterior over A, i.e.
+        $A = E_{Q(A)}[P(o|s,A)]$.
 
-        This is the so-called 'fully-connected' version where all hidden state factors drive each modality (i.e. A_dependencies is a list of lists of hidden state factors)
+        This is the so-called 'fully-connected' version where all hidden state factors drive each modality
+        (i.e. A_dependencies is a list of lists of hidden state factors)
         """
 
-        num_obs_list = [ [5], 
-                        [10, 3, 2], 
-                        [2, 4, 4, 2],
-                        [10]
-                        ]
-        num_states_list = [ [2,3,4], 
-                        [2], 
-                        [4,5],
-                        [3] 
-                        ]
+        num_obs_list = [[5], [10, 3, 2], [2, 4, 4, 2], [10]]
+        num_states_list = [[2, 3, 4], [2], [4, 5], [3]]
 
-        A_dependencies_list = [ [ [0,1,2] ],
-                                [ [0], [0], [0] ],
-                                [ [0,1], [0,1], [0,1], [0,1] ],
-                                [ [0] ]
-                                ]
+        A_dependencies_list = [[[0, 1, 2]], [[0], [0], [0]], [[0, 1], [0, 1], [0, 1], [0, 1]], [[0]]]
 
-        for (num_obs, num_states, A_dependencies) in zip(num_obs_list, num_states_list, A_dependencies_list):
+        for num_obs, num_states, A_dependencies in zip(num_obs_list, num_states_list, A_dependencies_list):
             # create numpy arrays to test numpy version of learning
 
             # create A matrix initialization (expected initial value of P(o|s, A)) and prior over A (pA)
             A_np = utils.random_A_matrix(num_obs, num_states)
-            pA_np = utils.dirichlet_like(A_np, scale = 3.0)
+            pA_np = utils.dirichlet_like(A_np, scale=3.0)
 
-            # create random observations 
+            # create random observations
             obs_np = utils.obj_array(len(num_obs))
             for m, obs_dim in enumerate(num_obs):
                 obs_np[m] = utils.onehot(np.random.randint(obs_dim), obs_dim)
@@ -75,37 +76,27 @@ class TestLearningJax(unittest.TestCase):
 
     def test_update_observation_likelihood_factorized(self):
         """
-        Testing JAX-ified version of updating Dirichlet posterior over observation likelihood parameters (qA is posterior, pA is prior, and A is expectation
-        of likelihood wrt to current posterior over A, i.e. $A = E_{Q(A)}[P(o|s,A)]$.
+        Testing JAX-ified version of updating Dirichlet posterior over observation likelihood parameters (qA is
+        posterior, pA is prior, and A is expectation of likelihood wrt to current posterior over A, i.e.
+        $A = E_{Q(A)}[P(o|s,A)]$.
 
-        This is the factorized version where only some hidden state factors drive each modality (i.e. A_dependencies is a list of lists of hidden state factors)
+        This is the factorized version where only some hidden state factors drive each modality (i.e. A_dependencies is
+        a list of lists of hidden state factors)
         """
 
-        num_obs_list = [ [5], 
-                        [10, 3, 2], 
-                        [2, 4, 4, 2],
-                        [10]
-                        ]
-        num_states_list = [ [2,3,4], 
-                        [2, 5, 2], 
-                        [4,5],
-                        [3] 
-                        ]
+        num_obs_list = [[5], [10, 3, 2], [2, 4, 4, 2], [10]]
+        num_states_list = [[2, 3, 4], [2, 5, 2], [4, 5], [3]]
 
-        A_dependencies_list = [ [ [0,1] ],
-                                [ [0, 1], [1], [1, 2] ],
-                                [ [0,1], [0], [0,1], [1] ],
-                                [ [0] ]
-                                ]
+        A_dependencies_list = [[[0, 1]], [[0, 1], [1], [1, 2]], [[0, 1], [0], [0, 1], [1]], [[0]]]
 
-        for (num_obs, num_states, A_dependencies) in zip(num_obs_list, num_states_list, A_dependencies_list):
+        for num_obs, num_states, A_dependencies in zip(num_obs_list, num_states_list, A_dependencies_list):
             # create numpy arrays to test numpy version of learning
 
             # create A matrix initialization (expected initial value of P(o|s, A)) and prior over A (pA)
             A_np = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_dependencies)
-            pA_np = utils.dirichlet_like(A_np, scale = 3.0)
+            pA_np = utils.dirichlet_like(A_np, scale=3.0)
 
-            # create random observations 
+            # create random observations
             obs_np = utils.obj_array(len(num_obs))
             for m, obs_dim in enumerate(num_obs):
                 obs_np[m] = utils.onehot(np.random.randint(obs_dim), obs_dim)
@@ -125,15 +116,289 @@ class TestLearningJax(unittest.TestCase):
             qA_jax_test = update_pA_jax(pA_jax, obs_jax, qs_jax, A_dependencies, lr=l_rate)
 
             for modality, obs_dim in enumerate(num_obs):
-                self.assertTrue(np.allclose(qA_jax_test[modality],qA_np_test[modality]))
+                self.assertTrue(np.allclose(qA_jax_test[modality], qA_np_test[modality]))
+
+    def test_update_state_likelihood_single_factor_no_actions(self):
+        """
+        Testing the JAXified version of updating Dirichlet posterior over transition likelihood parameters.
+        qB is the posterior, pB is the prior and B is the expectation of the likelihood wrt the
+        current posterior over B, i.e. $B = E_Q(B)[P(s_t | s_{t-1}, u_{t-1}, B)]
+        """
+
+        num_states = [3]
+        num_controls = [1]
+
+        l_rate = 1.0
+
+        # Create random variables to run the update on
+        qs_prev = utils.random_single_categorical(num_states)
+        qs = utils.random_single_categorical(num_states)
+
+        B = utils.random_B_matrix(num_states, num_controls)
+        pB = utils.obj_array_ones([B_f.shape for B_f in B])
+        action = np.array([np.random.randint(c_dim) for c_dim in num_controls])
+
+        pB_updated_numpy = update_pB_numpy(pB, B, action, qs, qs_prev, lr=l_rate, factors="all")
+
+        pB_jax = [jnp.array(b) for b in pB]
+        B_deps = [[0]]
+
+        # Add the batch dim
+        action_jax = jnp.array([action])
+
+        belief_jax = []
+        for f in range(len(num_states)):
+            # Extract factor + add batch dim
+            q_f = jnp.array([qs[..., f].tolist()])
+            q_prev_f = jnp.array([qs_prev[..., f].tolist()])
+            belief_jax.append([q_f, q_prev_f])
+
+        pB_updated_jax, _ = update_pB_jax(
+            pB_jax, belief_jax, action_jax, num_controls=num_controls, B_dependencies=B_deps, lr=l_rate
+        )
+
+        for pB_np, pB_jax in zip(pB_updated_numpy, pB_updated_jax):
+            self.assertTrue(pB_np.shape == pB_jax.shape)
+            self.assertTrue(np.allclose(pB_np, pB_jax))
+
+    def test_update_state_likelihood_single_factor_with_actions(self):
+        """
+        Testing the JAXified version of updating Dirichlet posterior over transition likelihood parameters.
+        qB is the posterior, pB is the prior and B is the expectation of the likelihood wrt the
+        current posterior over B, i.e. $B = E_Q(B)[P(s_t | s_{t-1}, u_{t-1}, B)]
+        """
+
+        num_states = [3]
+        num_controls = [3]
+
+        l_rate = 1.0
+
+        # Create random variables to run the update on
+        qs_prev = utils.random_single_categorical(num_states)
+        qs = utils.random_single_categorical(num_states)
+
+        B = utils.random_B_matrix(num_states, num_controls)
+        pB = utils.obj_array_ones([B_f.shape for B_f in B])
+        action = np.array([np.random.randint(c_dim) for c_dim in num_controls])
+
+        pB_updated_numpy = update_pB_numpy(pB, B, action, qs, qs_prev, lr=l_rate, factors="all")
+
+        # Add the batch dim
+        action_jax = jnp.array([action])
+
+        belief_jax = []
+        for f in range(len(num_states)):
+            # Extract factor + add batch dim
+            q_f = jnp.array([qs[..., f].tolist()])
+            q_prev_f = jnp.array([qs_prev[..., f].tolist()])
+            belief_jax.append([q_f, q_prev_f])
+
+        pB_jax = [jnp.array(b) for b in pB]
+
+        B_deps = [[i] for i, _ in enumerate(B)]
+        pB_updated_jax, _ = update_pB_jax(
+            pB_jax, belief_jax, action_jax, num_controls=num_controls, B_dependencies=B_deps, lr=l_rate
+        )
+
+        for pB_np, pB_jax in zip(pB_updated_numpy, pB_updated_jax):
+            self.assertTrue(pB_np.shape == pB_jax.shape)
+            self.assertTrue(np.allclose(pB_np, pB_jax))
+
+    def test_update_state_likelihood_multi_factor_all_factors_no_actions(self):
+        """
+        Testing the JAXified version of updating Dirichlet posterior over transition likelihood parameters.
+        qB is the posterior, pB is the prior and B is the expectation of the likelihood wrt the
+        current posterior over B, i.e. $B = E_Q(B)[P(s_t | s_{t-1}, u_{t-1}, B)]$
+        """
+
+        num_states = [3, 4]
+        num_controls = [1, 1]
+        qs_prev = utils.random_single_categorical(num_states)
+        qs = utils.random_single_categorical(num_states)
+        l_rate = 1.0
+
+        B = utils.random_B_matrix(num_states, num_controls)
+        pB = utils.obj_array_ones([B_f.shape for B_f in B])
+
+        action = np.array([np.random.randint(c_dim) for c_dim in num_controls])
+
+        pB_updated_numpy = update_pB_numpy(pB, B, action, qs, qs_prev, lr=l_rate, factors="all")
+
+        # Add the batch dim
+        action_jax = jnp.array([action])
+
+        belief_jax = []
+        for f in range(len(num_states)):
+            # Extract factor + add batch dim
+            q_f = jnp.array([qs[..., f].tolist()])
+            q_prev_f = jnp.array([qs_prev[..., f].tolist()])
+            belief_jax.append([q_f, q_prev_f])
+
+        # Also add the time and batch dimension
+        # action = jnp.expand_dims(jnp.array(action), 0)
+        pB_jax = [jnp.array(b) for b in pB]
+
+        pB_updated_jax, _ = update_pB_jax(
+            pB_jax, belief_jax, action_jax, num_controls=num_controls, B_dependencies=None, lr=l_rate
+        )
+
+        for pB_np, pB_jax in zip(pB_updated_numpy, pB_updated_jax):
+            self.assertTrue(pB_np.shape == pB_jax.shape)
+            self.assertTrue(np.allclose(pB_np, pB_jax))
+
+    def test_update_state_likelihood_multi_factor_all_factors_with_actions(self):
+        """
+        Testing the JAXified version of updating Dirichlet posterior over transition likelihood parameters.
+        qB is the posterior, pB is the prior and B is the expectation of the likelihood wrt the
+        current posterior over B, i.e. $B = E_Q(B)[P(s_t | s_{t-1}, u_{t-1}, B)]$
+        """
+        num_states = [3, 4]
+        num_controls = [3, 5]
+        qs_prev = utils.random_single_categorical(num_states)
+        qs = utils.random_single_categorical(num_states)
+        l_rate = 1.0
+
+        B = utils.random_B_matrix(num_states, num_controls)
+        pB = utils.obj_array_ones([B_f.shape for B_f in B])
+
+        action = np.array([np.random.randint(c_dim) for c_dim in num_controls])
+
+        pB_updated_numpy = update_pB_numpy(pB, B, action, qs, qs_prev, lr=l_rate, factors="all")
+
+        # Add the batch dim
+        action_jax = jnp.array([action])
+
+        belief_jax = []
+        for f in range(len(num_states)):
+            # Extract factor + add batch dim
+            q_f = jnp.array([qs[..., f].tolist()])
+            q_prev_f = jnp.array([qs_prev[..., f].tolist()])
+            belief_jax.append([q_f, q_prev_f])
+
+        pB_jax = [jnp.array(b) for b in pB]
+
+        B_deps = [[i] for i, _ in enumerate(B)]
+        pB_updated_jax, _ = update_pB_jax(
+            pB_jax, belief_jax, action_jax, num_controls=num_controls, B_dependencies=B_deps, lr=l_rate
+        )
+
+        for pB_np, pB_jax in zip(pB_updated_numpy, pB_updated_jax):
+            self.assertTrue(pB_np.shape == pB_jax.shape)
+            self.assertTrue(np.allclose(pB_np, pB_jax))
+
+    def test_update_state_likelihood_multi_factor_some_factors_no_action(self):
+        """
+        Testing the JAXified version of updating Dirichlet posterior over transition likelihood parameters.
+        qB is the posterior, pB is the prior and B is the expectation of the likelihood wrt the
+        current posterior over B, i.e. $B = E_Q(B)[P(s_t | s_{t-1}, u_{t-1}, B)]$
+        """
+        np.random.seed(0)
+
+        num_states = [3, 4, 2]
+        num_controls = [3, 5, 5]
+        qs_prev = utils.random_single_categorical(num_states)
+        qs = utils.random_single_categorical(num_states)
+        l_rate = 1.0
+
+        B = utils.random_B_matrix(num_states, num_controls)
+        pB = utils.obj_array_ones([B_f.shape for B_f in B])
+
+        action = list(np.array([np.random.randint(c_dim) for c_dim in num_controls]))
+
+        factors_to_update = np.random.choice(list(range(len(B))), replace=False, size=(2,)).tolist()
+
+        pB_updated_numpy = update_pB_numpy(pB, B, action, qs, qs_prev, lr=l_rate, factors=factors_to_update)
+
+        belief_jax = []
+        for f in range(len(num_states)):
+            # Extract factor + add batch dim
+            q_f = jnp.array([qs[..., f].tolist()])
+            q_prev_f = jnp.array([qs_prev[..., f].tolist()])
+            belief_jax.append([q_f, q_prev_f])
+
+        pB_jax = [jnp.array(b) for b in pB]
+
+        # Add the batch dim
+        action_jax = jnp.array([action])
+
+        # Selective update of factors is not implemented within the method, and could be performed like this:
+        pB_jax_update = [pB_jax[f] for f in factors_to_update]
+        belief_jax_update = [belief_jax[f] for f in factors_to_update]
+        action_jax_update = jnp.concatenate([action_jax[..., f : f + 1] for f in factors_to_update], axis=-1)
+        num_controls_update = [num_controls[f] for f in factors_to_update]
+
+        pB_updated_jax_factors, _ = update_pB_jax(
+            pB_jax_update,
+            belief_jax_update,
+            action_jax_update,
+            num_controls=num_controls_update,
+            B_dependencies=None,
+            lr=l_rate,
+        )
+
+        pB_updated_jax = []
+        for f, _ in enumerate(num_states):
+            if f in factors_to_update:
+                pB_updated_jax.append(pB_updated_jax_factors[factors_to_update.index(f)])
+            else:
+                pB_updated_jax.append(pB_jax[f])
+
+        for pB_np, pB_jax in zip(pB_updated_numpy, pB_updated_jax):
+            self.assertTrue(pB_np.shape == pB_jax.shape)
+            self.assertTrue(np.allclose(pB_np, pB_jax))
+
+    def test_update_state_likelihood_with_interactions(self):
+        """
+        Test for `learning.update_state_likelihood_dirichlet_factorized`, which is the learning function updating prior
+        Dirichlet parameters over the transition likelihood (pB) in the case that there are allowable interactions
+        between hidden state factors, i.e. the dynamics of factor `f` may depend on more than just its control factor
+        and its own state.
+        """
+
+        """ Test version with interactions """
+        num_states = [3, 4, 5]
+        num_controls = [2, 1, 1]
+        B_factor_list = [[0, 1], [0, 1, 2], [1, 2]]
+
+        qs_prev = utils.random_single_categorical(num_states)
+        qs = utils.random_single_categorical(num_states)
+
+        B = utils.random_B_matrix(num_states, num_controls, B_factor_list=B_factor_list)
+        pB = utils.dirichlet_like(B, scale=1.0)
+        l_rate = np.random.rand()  # sample some positive learning rate
+
+        action = np.array([np.random.randint(c_dim) for c_dim in num_controls])
+
+        pB_updated_numpy = update_pB_interactions_numpy(
+            pB, B, action, qs, qs_prev, B_factor_list, lr=l_rate, factors="all"
+        )
+
+        # Add the batch dim
+        action_jax = jnp.array([action])
+
+        belief_jax = []
+        for f in range(len(num_states)):
+            # Extract factor + add batch dim
+            q_f = jnp.array([qs[..., f].tolist()])
+            q_prev_f = jnp.array([qs_prev[..., f].tolist()])
+            belief_jax.append([q_f, q_prev_f])
+
+        pB_jax = [jnp.array(b) for b in pB]
+
+        pB_updated_jax, _ = update_pB_jax(
+            pB_jax, belief_jax, action_jax, B_dependencies=B_factor_list, lr=l_rate, num_controls=num_controls
+        )
+
+        for pB_np, pB_jax in zip(pB_updated_numpy, pB_updated_jax):
+            self.assertTrue(pB_np.shape == pB_jax.shape)
+            self.assertTrue(np.allclose(pB_np, pB_jax))
+
 
 if __name__ == "__main__":
-    unittest.main()
-
-
-
-
-
-
-
-
+    TestLearningJax().test_update_state_likelihood_single_factor_no_actions()
+    TestLearningJax().test_update_state_likelihood_single_factor_with_actions()
+    TestLearningJax().test_update_state_likelihood_multi_factor_all_factors_no_actions()
+    TestLearningJax().test_update_state_likelihood_multi_factor_all_factors_with_actions()
+    TestLearningJax().test_update_state_likelihood_multi_factor_some_factors_no_action()
+    TestLearningJax().test_update_state_likelihood_with_interactions()
+    # unittest.main()

--- a/test/test_learning_jax.py
+++ b/test/test_learning_jax.py
@@ -355,23 +355,12 @@ class TestLearningJax(unittest.TestCase):
         action_jax = jnp.array([action])
 
         # Selective update of factors is not implemented within the method, and could be performed like this:
-        pB_jax_update = [pB_jax[f] for f in factors_to_update]
-        belief_jax_update = [belief_jax[f] for f in factors_to_update]
-        action_jax_update = jnp.concatenate([action_jax[..., f : f + 1] for f in factors_to_update], axis=-1)
-        num_controls_update = [num_controls[f] for f in factors_to_update]
 
         pB_updated_jax_factors, _ = update_pB_jax(
             pB_jax, belief_jax, action_jax, num_controls=num_controls, lr=l_rate, factors_to_update=factors_to_update
         )
 
-        pB_updated_jax = []
-        for f, _ in enumerate(num_states):
-            if f in factors_to_update:
-                pB_updated_jax.append(pB_updated_jax_factors[factors_to_update.index(f)])
-            else:
-                pB_updated_jax.append(pB_jax[f])
-
-        for pB_np, pB_jax in zip(pB_updated_numpy, pB_updated_jax):
+        for pB_np, pB_jax in zip(pB_updated_numpy, pB_updated_jax_factors):
             self.assertTrue(pB_np.shape == pB_jax.shape)
             self.assertTrue(np.allclose(pB_np, pB_jax))
 


### PR DESCRIPTION
- This branch started from the files `pymdp.jax.learning.py` and `test/test_learning_jax.py` from the master branch: updates in `pymdp.jax.learning.py` are lines 70-107 and in test_learning_jax.py are lines 117-EOF. 
- added unit tests to compare performance against the numpy equivalent of these methods. 
- Added the `factors_to_update` functionality to only update certain state modalities of the transition matrix + tested against their numpy equivalent
- Added docstring to `update_state_transition_dirichlet` 