### PR TITLE
Loosen Python Version Requirement to 3.10 & Add setup.cfg for Jetson Compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python :: 3',
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
     'numpy>=1.19.5', 
     'jax>=0.3.4',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,52 @@
 [metadata]
-name = pymdp
+name = inferactively-pymdp
 version = 1.0.0
 description = A Python package for solving Markov Decision Processes with Active Inference
+long_description = file: README.md
+long_description_content_type = text/markdown
 author = Conor Heins, Alexander Tschantz, Tim Verbelen, Dimitrije Markovic
+author_email = conor.heins@gmail.com, tschantz.alec@gmail.com, verbelen.tim@gmail.com, dimitrije.markovic@tu-dresden.de
 license = MIT
+license_file = LICENSE
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    Topic :: Scientific/Engineering :: Artificial Intelligence
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3
+python_requires = >=3.10
+project_urls =
+    Documentation = https://pymdp-rtd.readthedocs.io/en/stable/
+    Repository = https://github.com/infer-actively/pymdp
 
 [options]
 packages = find:
-python_requires = >=3.10
+install_requires =
+    numpy>=1.19.5
+    jax>=0.3.4
+    jaxlib>=0.3.4
+    equinox>=0.9
+    multimethod>=1.11
+    matplotlib>=3.1.3
+    seaborn>=0.11.1
+    mctx>=0.0.5
+    networkx>=3.3
+    pytest>=6.2.1
+include_package_data = True
+
+[options.extras_require]
+gpu =
+    jax[cuda12]>=0.3.4
+    jaxlib[cuda12]>=0.3.4
 
 [options.package_data]
 pymdp = envs/assets/*
+
+[options.packages.find]
+where = .
+
+[tool:pytest]
+minversion = 6.2.1
+
+[flake8]
+max-line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[metadata]
+name = pymdp
+version = 1.0.0
+description = A Python package for solving Markov Decision Processes with Active Inference
+author = Conor Heins, Alexander Tschantz, Tim Verbelen, Dimitrije Markovic
+license = MIT
+
+[options]
+packages = find:
+python_requires = >=3.10
+
+[options.package_data]
+pymdp = envs/assets/*


### PR DESCRIPTION
This pull request adjusts the minimum Python requirement for **pymdp v1.0.0_alpha** from 3.11 to **3.10** to support broader environments, including Jetson devices running Python 3.10. Additionally, a setup.cfg file is introduced, as pyproject.toml could not be used for proper installation on Jetson platforms. These changes have been tested on Jetson Orin Nano with JetPack 6.1 to ensure smooth installation and usage.