### PR TITLE
Fix to `infer_parameters()` in `jax/agent.py` 

### DIFF
--- a/pymdp/jax/agent.py
+++ b/pymdp/jax/agent.py
@@ -298,6 +298,7 @@ class Agent(Module):
             lr = jnp.broadcast_to(lr_pB, (self.batch_size,))
             qB, E_qB = vmap(update_B)(
                 self.pB,
+                self.B,
                 joint_beliefs,
                 actions,
                 lr=lr


### PR DESCRIPTION
Adds `self.B`as second argument to the local `update_B` function to respect new argument structure of `jax/learning/update_state_transition_dirichlet()` introduced by 69dee71