### PR TITLE
suggested solution for BUG: Shape miscalculation in np.squeeze(X) in dot_likelihood() (pymdp.maths.py) #171

### DIFF
--- a/pymdp/maths.py
+++ b/pymdp/maths.py
@@ -242,7 +242,7 @@ def dot_likelihood(A,obs):
     s[0] = obs.shape[0]
     X = A * obs.reshape(tuple(s))
     X = np.sum(X, axis=0, keepdims=True)
-    LL = np.squeeze(X)
+    LL = np.squeeze(X, axis=0)
 
     # check to see if `LL` is a scalar
     if np.prod(LL.shape) <= 1.0:


### PR DESCRIPTION
This is the suggested ammendmant for the solution of

BUG: Shape miscalculation in np.squeeze(X) in dot_likelihood() (pymdp.maths.py) #171

https://github.com/infer-actively/pymdp/issues/171