### PR TITLE
Fix/173 rename apply batch to batch size

### DIFF
--- a/examples/envs/tmaze_demo.ipynb
+++ b/examples/envs/tmaze_demo.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# T-Maze Demo\n",
     "\n",
-    "In this notebook, we simulate an active inference agent solving the T-Maze task - a type of two-armed contextual bandit. Note that unlike n earlier demos in the legacy version of the [`pymdp` package](https://pymdp-rtd.readthedocs.io/en/latest/) which has a `NumPy` backend, this demo relies on `pymdp`'s new `jax` backend. The JAX backend accelerates `pymdp` by dispatching the core inference, learning and planning computations to CUDA-compatible GPU devices (if enabled). This, in combination with JAX's just-in-time (JIT) compilation features, enables pymdp to take advantage of batch processing (i.e., running many AIF processes in parallel) and increased memory-usage / speed, especially recurrent operations (e.g., iterative inference routines or processes that run over time)."
+    "In this notebook, we simulate an active inference agent solving the T-Maze task - a type of two-armed contextual bandit. Note that unlike in earlier demos in the legacy version of the [`pymdp` package](https://pymdp-rtd.readthedocs.io/en/latest/) which has a `NumPy` backend, this demo relies on `pymdp`'s new `jax` backend. The JAX backend accelerates `pymdp` by dispatching the core inference, learning and planning computations to CUDA-compatible GPU devices (if available). This, in combination with JAX's just-in-time (JIT) compilation features, enables pymdp to take advantage of batch processing (i.e., running many AIF processes in parallel) and increased memory-usage / speed, especially recurrent operations (e.g., iterative inference routines or processes that run over time)."
    ]
   },
   {

--- a/examples/envs/tmaze_demo.ipynb
+++ b/examples/envs/tmaze_demo.ipynb
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +214,7 @@
     "    policy_len=2, # how long the action sequence is that the agent is evaluating\n",
     "    A_dependencies=A_dependencies, \n",
     "    B_dependencies=B_dependencies,\n",
-    "    apply_batch=False,\n",
+    "    batch_size=batch_size,\n",
     "    learn_A=False,\n",
     "    learn_B=False\n",
     ")\n",
@@ -235,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -322,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -389,7 +389,7 @@
     "    policy_len=2,\n",
     "    A_dependencies=A_dependencies, \n",
     "    B_dependencies=B_dependencies,\n",
-    "    apply_batch=False,\n",
+    "    batch_size=batch_size,\n",
     "    learn_A=False,\n",
     "    learn_B=False\n",
     ")\n",
@@ -428,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -454,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -493,7 +493,7 @@
     "    policy_len=3, # how long the action sequence is that the agent is evaluating\n",
     "    A_dependencies=A_dependencies, \n",
     "    B_dependencies=B_dependencies,\n",
-    "    apply_batch=False,\n",
+    "    batch_size=batch_size,\n",
     "    learn_A=False,\n",
     "    learn_B=False\n",
     ")\n",
@@ -505,7 +505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -562,7 +562,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,7 +594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -645,7 +645,7 @@
     "    policy_len=5, # how long the action sequence is that the agent is evaluating\n",
     "    A_dependencies=A_dependencies, \n",
     "    B_dependencies=B_dependencies,\n",
-    "    apply_batch=False, \n",
+    "    batch_size=batch_size, \n",
     "    learn_A=True,\n",
     "    learn_B=False,\n",
     "    gamma=1.0,\n",
@@ -655,7 +655,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -673,7 +673,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -710,7 +710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -750,7 +750,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -783,7 +783,7 @@
     "    policy_len=5, # how long the action sequence is that the agent is evaluating\n",
     "    A_dependencies=A_dependencies, \n",
     "    B_dependencies=B_dependencies,\n",
-    "    apply_batch=False, \n",
+    "    batch_size=batch_size, \n",
     "    learn_A=True,\n",
     "    learn_B=True,\n",
     "    gamma=0.1,\n",
@@ -798,7 +798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -835,7 +835,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -869,7 +869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {

--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -138,7 +138,7 @@ class Agent(Module):
         learn_E=False,
     ):
         if B_action_dependencies is not None:
-            assert num_controls is not None, "Please specify num_controls for complex action dependencies"
+            assert num_controls is not None, "Please specify num_controls if you're also using complex action dependencies"
 
         # extract high level variables
         self.num_modalities = len(A)
@@ -169,7 +169,6 @@ class Agent(Module):
 
         # flatten B action dims for multiple action dependencies
         self.action_maps = None
-        self.num_controls_multi = num_controls
         if (
             B_action_dependencies is not None
         ):  # note, this only works when B_action_dependencies is not the trivial case of [[0], [1], ...., [num_factors-1]]

--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -130,7 +130,7 @@ class Agent(Module):
         sampling_mode="full",
         inference_algo="fpi",
         num_iter=16,
-        apply_batch=True,
+        batch_size=1,
         learn_A=True,
         learn_B=True,
         learn_C=False,
@@ -165,7 +165,7 @@ class Agent(Module):
         if H is not None:
             H = [jnp.array(h.data) if isinstance(h, Distribution) else h for h in H]
 
-        self.batch_size = A[0].shape[0] if not apply_batch else 1
+        self.batch_size = batch_size
 
         # flatten B action dims for multiple action dependencies
         self.action_maps = None
@@ -183,11 +183,51 @@ class Agent(Module):
             policies = self._construct_flattend_policies(policies_multi, self.action_maps)
             self.sampling_mode = "full"
 
+        # check that batch_size is consistent with shapes of given A and B
+        for m, a_m in enumerate(A):
+            a_m_state_factors = tuple([self.num_states[f] for f in self.A_dependencies[m]])
+            if a_m.ndim > (len(a_m_state_factors) + 1): # this indicates there's a leading batch dimension
+                if a_m.shape[0] == 1 and batch_size > 1:
+                    A[m] = jnp.broadcast_to(a_m, (batch_size,) + a_m.shape[1:])
+                    if pA is not None:
+                        pA[m] = jnp.broadcast_to(pA[m], (batch_size,) + a_m.shape[1:])
+                    if C is not None:
+                        C[m] = jnp.broadcast_to(C[m], (batch_size,) + C[m].shape[1:])
+                elif a_m.shape[0] != batch_size:
+                    raise ValueError(
+                        f"Batch size {batch_size} does not match the first dimension of A[{m}] with shape {a_m.shape}"
+                    )
+            elif a_m.ndim == (len(a_m_state_factors) + 1):  # this indicates no leading batch dimension
+                A[m] = jnp.broadcast_to(a_m, (batch_size,) + a_m.shape)
+                if pA is not None:
+                    pA[m] = jnp.broadcast_to(pA[m], (batch_size,) + a_m.shape)
+                if C is not None:
+                    C[m] = jnp.broadcast_to(C[m], (batch_size,) + C[m].shape)
+        
+        for f, b_f in enumerate(B):
+            b_f_state_factors = tuple([self.num_states[f] for f in self.B_dependencies[f]])
+            if b_f.ndim > (len(b_f_state_factors) + 1):  # this indicates there's a leading batch dimension
+                if b_f.shape[0] == 1 and batch_size > 1:
+                    B[f] = jnp.broadcast_to(b_f, (batch_size,) + b_f.shape[1:])
+                    if pB is not None:
+                        pB[f] = jnp.broadcast_to(pB[f], (batch_size,) + b_f.shape[1:])
+                    if D is not None:
+                        D[f] = jnp.broadcast_to(D[f], (batch_size,) + D[f].shape[1:])
+                elif b_f.shape[0] != batch_size:
+                    raise ValueError(
+                        f"Batch size {batch_size} does not match the first dimension of B[{f}] with shape {b_f.shape}"
+                    )
+            elif b_f.ndim == (len(b_f_state_factors) + 1):  # this indicates no leading batch dimension
+                B[f] = jnp.broadcast_to(b_f, (batch_size,) + b_f.shape)
+                if pB is not None:
+                    pB[f] = jnp.broadcast_to(pB[f], (batch_size,) + b_f.shape)
+                if D is not None:
+                    D[f] = jnp.broadcast_to(D[f], (batch_size,) + D[f].shape)
+
         # extract shapes from A and B
-        batch_dim_fn = lambda x: x.shape[0] if apply_batch else x.shape[1]
-        self.num_states = jtu.tree_map(batch_dim_fn, B)
-        self.num_obs = jtu.tree_map(batch_dim_fn, A)
-        self.num_controls = [B[f].shape[-1] for f in range(self.num_factors)]
+        self.num_states = [x.shape[1] for x in B]
+        self.num_obs = [x.shape[1] for x in A]
+        self.num_controls = [x.shape[-1] for x in B]
 
         # static parameters
         self.num_iter = num_iter
@@ -229,37 +269,36 @@ class Agent(Module):
         else:
             self.policies = policies
 
-        # setup pytree leaves A, B, C, D, E, pA, pB, H, I
-        if apply_batch:
-            A = jtu.tree_map(lambda x: jnp.broadcast_to(x, (self.batch_size,) + x.shape), A)
-            B = jtu.tree_map(lambda x: jnp.broadcast_to(x, (self.batch_size,) + x.shape), B)
-
-        if pA is not None and apply_batch:
-            pA = jtu.tree_map(lambda x: jnp.broadcast_to(x, (self.batch_size,) + x.shape), pA)
-
-        if pB is not None and apply_batch:
-            pB = jtu.tree_map(lambda x: jnp.broadcast_to(x, (self.batch_size,) + x.shape), pB)
-
         if C is None:
             C = [jnp.ones((self.batch_size, self.num_obs[m])) / self.num_obs[m] for m in range(self.num_modalities)]
-        elif apply_batch:
-            C = jtu.tree_map(lambda x: jnp.broadcast_to(x, (self.batch_size,) + x.shape), C)
-
+    
         if D is None:
             D = [jnp.ones((self.batch_size, self.num_states[f])) / self.num_states[f] for f in range(self.num_factors)]
-        elif apply_batch:
-            D = jtu.tree_map(lambda x: jnp.broadcast_to(x, (self.batch_size,) + x.shape), D)
 
         if E is None:
             E = jnp.ones((self.batch_size, len(self.policies))) / len(self.policies)
-        elif apply_batch:
-            E = jnp.broadcast_to(E, (self.batch_size,) + E.shape)
+        else:
+            if E.ndim > 1:
+                if E.shape[0] == 1 and batch_size > 1:
+                    E = jnp.broadcast_to(E, (batch_size,) + E.shape[1:])
+                elif E.shape[0] != batch_size:
+                    raise ValueError(
+                        f"Batch size {batch_size} does not match the first dimension of E with shape {E.shape}"
+                    )
+            elif E.ndim == 1:
+                E = jnp.broadcast_to(E, (self.batch_size,) + E.shape)
 
-        if H is not None and apply_batch:
-            H = jtu.tree_map(
-                lambda x: jnp.broadcast_to(x, (self.batch_size,) + x.shape),
-                H,
-            )
+        if H is not None:
+            for f, h_f in enumerate(H):
+                if h_f.ndim > 1:
+                    if h_f.shape[0] == 1 and batch_size > 1:
+                        H[f] = jnp.broadcast_to(h_f, (batch_size,) + h_f.shape[1:])
+                    elif h_f.shape[0] != batch_size:
+                        raise ValueError(
+                            f"Batch size {batch_size} does not match the first dimension of H[{f}] with shape {h_f.shape}"
+                        )
+                elif h_f.ndim == 1:
+                    H[f] = jnp.broadcast_to(h_f, (self.batch_size,) + h_f.shape)
 
         self.A = A
         self.B = B

--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -206,7 +206,7 @@ class Agent(Module):
         
         for f, b_f in enumerate(B):
             b_f_state_factors = tuple([self.num_states[f] for f in self.B_dependencies[f]])
-            if b_f.ndim > (len(b_f_state_factors) + 1):  # this indicates there's a leading batch dimension
+            if b_f.ndim > (len(b_f_state_factors) + 2):  # this indicates there's a leading batch dimension
                 if b_f.shape[0] == 1 and batch_size > 1:
                     B[f] = jnp.broadcast_to(b_f, (batch_size,) + b_f.shape[1:])
                     if pB is not None:
@@ -217,7 +217,7 @@ class Agent(Module):
                     raise ValueError(
                         f"Batch size {batch_size} does not match the first dimension of B[{f}] with shape {b_f.shape}"
                     )
-            elif b_f.ndim == (len(b_f_state_factors) + 1):  # this indicates no leading batch dimension
+            elif b_f.ndim == (len(b_f_state_factors) + 2):  # this indicates no leading batch dimension
                 B[f] = jnp.broadcast_to(b_f, (batch_size,) + b_f.shape)
                 if pB is not None:
                     pB[f] = jnp.broadcast_to(pB[f], (batch_size,) + b_f.shape)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,7 @@ gpu = [
     'jaxlib[cuda12]>=0.3.4',
 ]
 
-nb = 
-    [
+nb = [
         'mediapy>=1.2.4',
         'pygraphviz>=1.14',
     ]

--- a/test/test_agent_jax.py
+++ b/test/test_agent_jax.py
@@ -5,20 +5,19 @@
 __author__: Dimitrije Markovic, Conor Heins
 """
 
-import os
 import unittest
 
 import numpy as np
 import jax.numpy as jnp
 from jax import vmap, nn, random
 import jax.tree_util as jtu
+import math as pymath
 
 from pymdp.legacy import utils
 from pymdp.agent import Agent
 from pymdp.maths import compute_log_likelihood_single_modality
 from pymdp.utils import norm_dist
 from equinox import Module
-from typing import Any, List
 
 class TestAgentJax(unittest.TestCase):
 

--- a/test/test_agent_jax.py
+++ b/test/test_agent_jax.py
@@ -21,6 +21,309 @@ from equinox import Module
 
 class TestAgentJax(unittest.TestCase):
 
+    def test_no_desired_batch_no_batched_input_construction(self):
+        """
+        Tests for the case where the user wants no batch size, and they pass in tensors with no batch size
+        """
+
+        num_obs = [2, 3, 4]
+        num_states = [4, 5, 2]
+        num_controls = [2, 3, 1]
+
+        A_factor_list = [[0], [0, 1], [0, 1, 2]]
+        B_factor_list = [[0], [0, 1], [1, 2]]
+
+        A = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_factor_list)
+        B = utils.random_B_matrix(num_states, num_controls, B_factor_list=B_factor_list, B_factor_control_list=None)
+
+        agent = Agent(
+            A, B, 
+            A_dependencies=A_factor_list, 
+            B_dependencies=B_factor_list, 
+            num_controls=num_controls,
+        )
+
+        for m in range(len(num_obs)):
+            num_states_m = tuple([num_states[f] for f in A_factor_list[m]])
+            self.assertTrue(agent.A[m].shape == (1, num_obs[m]) + num_states_m)
+            self.assertTrue(agent.C[m].shape == (1, num_obs[m]))
+
+        for f in range(len(num_states)):
+            num_states_f = tuple([num_states[f] for f in B_factor_list[f]])
+            self.assertTrue(agent.B[f].shape == (1, num_states[f]) + num_states_f + (num_controls[f],))
+            self.assertTrue(agent.D[f].shape == (1, num_states[f]))
+        
+        self.assertTrue(agent.num_obs == num_obs)
+        self.assertTrue(agent.num_states == num_states)
+        self.assertTrue(agent.num_controls == num_controls)
+        
+        # Test the version with complex action dependencies
+        num_obs = [2, 3]
+        num_states = [4, 5, 2]
+        num_controls = [2, 3, 2]
+        A_factor_list = [[0, 1], [1]]
+        B_factor_list = [[0], [0, 1, 2], [2]]
+        B_factor_control_list = [[], [0, 1], [0, 2]]
+
+        A = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_factor_list)
+        B = utils.random_B_matrix(num_states, num_controls, B_factor_list=B_factor_list, B_factor_control_list=B_factor_control_list)
+
+        agent = Agent(
+            A, B, 
+            A_dependencies=A_factor_list, 
+            B_dependencies=B_factor_list, 
+            B_action_dependencies=B_factor_control_list,
+            num_controls=num_controls,
+            sampling_mode="full",
+        )
+
+        self.assertTrue(agent.num_obs == num_obs)
+        self.assertTrue(agent.num_states == num_states)
+
+        for m in range(len(num_obs)):
+            num_states_m = tuple([num_states[f] for f in A_factor_list[m]])
+            self.assertTrue(agent.A[m].shape == (1, num_obs[m]) + num_states_m)
+            self.assertTrue(agent.C[m].shape == (1, num_obs[m]))
+
+        num_controls_flattened = []
+        for f,action_dependency in enumerate(B_factor_control_list):
+            if action_dependency == []:
+                num_controls_f_flattened = 1
+            else:
+                num_controls_f_flattened = pymath.prod([num_controls[d] for d in action_dependency])
+
+            num_controls_flattened.append(num_controls_f_flattened)
+            num_states_f = tuple([num_states[f] for f in B_factor_list[f]])
+            self.assertTrue(agent.B[f].shape == (1, num_states[f]) + num_states_f + (num_controls_f_flattened,))
+            self.assertTrue(agent.D[f].shape == (1, num_states[f]))
+        self.assertTrue(agent.num_controls == num_controls_flattened)
+
+            
+    def test_desired_batch_no_batched_input_construction(self):
+        """
+        Tests for the case where the user wants > 1 batch size, and they pass in tensors with no batch size
+        """
+        num_obs = [2, 3, 4]
+        num_states = [4, 5, 2]
+        num_controls = [2, 3, 1]
+        desired_batch_size = 3
+
+        A_factor_list = [[0], [0, 1], [0, 1, 2]]
+        B_factor_list = [[0], [0, 1], [1, 2]]
+
+        A = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_factor_list)
+        B = utils.random_B_matrix(num_states, num_controls, B_factor_list=B_factor_list, B_factor_control_list=None)
+
+        agent = Agent(
+            A, B, 
+            A_dependencies=A_factor_list, 
+            B_dependencies=B_factor_list, 
+            num_controls=num_controls,
+            batch_size=desired_batch_size,
+        )
+
+        for m in range(len(num_obs)):
+            num_states_m = tuple([num_states[f] for f in A_factor_list[m]])
+            self.assertTrue(agent.A[m].shape == (desired_batch_size, num_obs[m]) + num_states_m)
+            self.assertTrue(agent.C[m].shape == (desired_batch_size, num_obs[m]))
+
+        for f in range(len(num_states)):
+            num_states_f = tuple([num_states[f] for f in B_factor_list[f]])
+            self.assertTrue(agent.B[f].shape == (desired_batch_size, num_states[f]) + num_states_f + (num_controls[f],))
+            self.assertTrue(agent.D[f].shape == (desired_batch_size, num_states[f]))
+        
+        self.assertTrue(agent.num_obs == num_obs)
+        self.assertTrue(agent.num_states == num_states)
+        self.assertTrue(agent.num_controls == num_controls)
+
+        # Test the version with complex action dependencies
+        num_obs = [2, 3]
+        num_states = [4, 5, 2]
+        num_controls = [2, 3, 2]
+        A_factor_list = [[0, 1], [1]]
+        B_factor_list = [[0], [0, 1, 2], [2]]
+        B_factor_control_list = [[], [0, 1], [0, 2]]
+        desired_batch_size = 3
+
+
+        A = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_factor_list)
+        B = utils.random_B_matrix(num_states, num_controls, B_factor_list=B_factor_list, B_factor_control_list=B_factor_control_list)
+
+        agent = Agent(
+            A, B, 
+            A_dependencies=A_factor_list, 
+            B_dependencies=B_factor_list, 
+            B_action_dependencies=B_factor_control_list,
+            num_controls=num_controls,
+            sampling_mode="full",
+            batch_size=desired_batch_size,
+        )
+
+        self.assertTrue(agent.num_obs == num_obs)
+        self.assertTrue(agent.num_states == num_states)
+
+        for m in range(len(num_obs)):
+            num_states_m = tuple([num_states[f] for f in A_factor_list[m]])
+            self.assertTrue(agent.A[m].shape == (desired_batch_size, num_obs[m]) + num_states_m)
+            self.assertTrue(agent.C[m].shape == (desired_batch_size, num_obs[m]))
+
+        num_controls_flattened = []
+        for f,action_dependency in enumerate(B_factor_control_list):
+            if action_dependency == []:
+                num_controls_f_flattened = 1
+            else:
+                num_controls_f_flattened = pymath.prod([num_controls[d] for d in action_dependency])
+
+            num_controls_flattened.append(num_controls_f_flattened)
+            num_states_f = tuple([num_states[f] for f in B_factor_list[f]])
+            self.assertTrue(agent.B[f].shape == (desired_batch_size, num_states[f]) + num_states_f + (num_controls_f_flattened,))
+            self.assertTrue(agent.D[f].shape == (desired_batch_size, num_states[f]))
+        self.assertTrue(agent.num_controls == num_controls_flattened)
+
+    def test_desired_batch_and_batched_input_construction(self):
+        """
+        Tests for the case where the user wants >= 1 batch size, and they pass in tensors with that correct >= 1 batch size
+        """
+        num_obs = [2, 3, 4]
+        num_states = [4, 5, 2]
+        num_controls = [2, 3, 1]
+
+        A_factor_list = [[0], [0, 1], [0, 1, 2]]
+        B_factor_list = [[0], [0, 1], [1, 2]]
+
+        A_single = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_factor_list)
+        B_single = utils.random_B_matrix(num_states, num_controls, B_factor_list=B_factor_list, B_factor_control_list=None)
+        A = [a[None,...] for a in A_single]
+        B = [b[None,...] for b in B_single]
+
+        agent = Agent(
+            A, B, 
+            A_dependencies=A_factor_list, 
+            B_dependencies=B_factor_list, 
+            num_controls=num_controls,
+            batch_size=1,
+        )
+
+        for m in range(len(num_obs)):
+            num_states_m = tuple([num_states[f] for f in A_factor_list[m]])
+            self.assertTrue(agent.A[m].shape == (1,) + (num_obs[m],) + num_states_m)
+            self.assertTrue(agent.C[m].shape == (1,) + (num_obs[m],))
+
+        for f in range(len(num_states)):
+            num_states_f = tuple([num_states[f] for f in B_factor_list[f]])
+            self.assertTrue(agent.B[f].shape == (1,) + (num_states[f],) + num_states_f + (num_controls[f],))
+            self.assertTrue(agent.D[f].shape == (1,) + (num_states[f],))
+        
+        self.assertTrue(agent.num_obs == num_obs)
+        self.assertTrue(agent.num_states == num_states)
+        self.assertTrue(agent.num_controls == num_controls)
+        
+        desired_batch_size = 3
+        A = [jnp.broadcast_to(a, (desired_batch_size,) + a.shape) for a in A_single]
+        B = [jnp.broadcast_to(b, (desired_batch_size,) + b.shape) for b in B_single]
+        agent = Agent(
+            A, B, 
+            A_dependencies=A_factor_list, 
+            B_dependencies=B_factor_list, 
+            num_controls=num_controls,
+            batch_size=desired_batch_size,
+        )
+
+        for m in range(len(num_obs)):
+            num_states_m = tuple([num_states[f] for f in A_factor_list[m]])
+            self.assertTrue(agent.A[m].shape == (desired_batch_size,) + (num_obs[m],) + num_states_m)
+            self.assertTrue(agent.C[m].shape == (desired_batch_size,) + (num_obs[m],))
+
+        for f in range(len(num_states)):
+            num_states_f = tuple([num_states[f] for f in B_factor_list[f]])
+            self.assertTrue(agent.B[f].shape == (desired_batch_size,) + (num_states[f],) + num_states_f + (num_controls[f],))
+            self.assertTrue(agent.D[f].shape == (desired_batch_size,) + (num_states[f],))
+        
+        self.assertTrue(agent.num_obs == num_obs)
+        self.assertTrue(agent.num_states == num_states)
+        self.assertTrue(agent.num_controls == num_controls)
+
+
+        ### Now test the version with complex action dependencies
+        num_obs = [2, 3]
+        num_states = [4, 5, 2]
+        num_controls = [2, 3, 2]
+        A_factor_list = [[0, 1], [1]]
+        B_factor_list = [[0], [0, 1, 2], [2]]
+        B_factor_control_list = [[], [0, 1], [0, 2]]
+
+        A_single = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_factor_list)
+        B_single = utils.random_B_matrix(num_states, num_controls, B_factor_list=B_factor_list, B_factor_control_list=B_factor_control_list)
+        A = [a[None,...] for a in A_single]
+        B = [b[None,...] for b in B_single]
+
+        agent = Agent(
+            A, B, 
+            A_dependencies=A_factor_list, 
+            B_dependencies=B_factor_list, 
+            B_action_dependencies=B_factor_control_list,
+            num_controls=num_controls,
+            sampling_mode="full",
+            batch_size=1,
+        )
+
+        self.assertTrue(agent.num_obs == num_obs)
+        self.assertTrue(agent.num_states == num_states)
+
+        for m in range(len(num_obs)):
+            num_states_m = tuple([num_states[f] for f in A_factor_list[m]])
+            self.assertTrue(agent.A[m].shape == (1, num_obs[m]) + num_states_m)
+            self.assertTrue(agent.C[m].shape == (1, num_obs[m]))
+
+        num_controls_flattened = []
+        for f,action_dependency in enumerate(B_factor_control_list):
+            if action_dependency == []:
+                num_controls_f_flattened = 1
+            else:
+                num_controls_f_flattened = pymath.prod([num_controls[d] for d in action_dependency])
+
+            num_controls_flattened.append(num_controls_f_flattened)
+            num_states_f = tuple([num_states[f] for f in B_factor_list[f]])
+            self.assertTrue(agent.B[f].shape == (1, num_states[f]) + num_states_f + (num_controls_f_flattened,))
+            self.assertTrue(agent.D[f].shape == (1, num_states[f]))
+        self.assertTrue(agent.num_controls == num_controls_flattened)
+
+        desired_batch_size = 3
+        A = [jnp.broadcast_to(a, (desired_batch_size,) + a.shape) for a in A_single]
+        B = [jnp.broadcast_to(b, (desired_batch_size,) + b.shape) for b in B_single]
+
+        agent = Agent(
+            A, B, 
+            A_dependencies=A_factor_list, 
+            B_dependencies=B_factor_list, 
+            B_action_dependencies=B_factor_control_list,
+            num_controls=num_controls,
+            sampling_mode="full",
+            batch_size=desired_batch_size,
+        )
+
+        self.assertTrue(agent.num_obs == num_obs)
+        self.assertTrue(agent.num_states == num_states)
+
+        for m in range(len(num_obs)):
+            num_states_m = tuple([num_states[f] for f in A_factor_list[m]])
+            self.assertTrue(agent.A[m].shape == (desired_batch_size, num_obs[m]) + num_states_m)
+            self.assertTrue(agent.C[m].shape == (desired_batch_size, num_obs[m]))
+
+        num_controls_flattened = []
+        for f,action_dependency in enumerate(B_factor_control_list):
+            if action_dependency == []:
+                num_controls_f_flattened = 1
+            else:
+                num_controls_f_flattened = pymath.prod([num_controls[d] for d in action_dependency])
+
+            num_controls_flattened.append(num_controls_f_flattened)
+            num_states_f = tuple([num_states[f] for f in B_factor_list[f]])
+            self.assertTrue(agent.B[f].shape == (desired_batch_size, num_states[f]) + num_states_f + (num_controls_f_flattened,))
+            self.assertTrue(agent.D[f].shape == (desired_batch_size, num_states[f]))
+        self.assertTrue(agent.num_controls == num_controls_flattened)
+
+
     def test_vmappable_agent_methods(self):
 
         dim, N = 5, 10


### PR DESCRIPTION
Removes `apply_batch` argument to `Agent()` constructor with `batch_size` which always defaults to `1`. To address #173 