### PR TITLE
setup a ruff lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,4 +26,4 @@ jobs:
         pip install ruff
     - name: Analysing the code with pylint
       run: |
-        ruff check $(git ls-files '*.py')
+        ruff check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,7 @@ on:
     paths:
       - '**.py'
       - '.github/workflows/lint.yml'
-      - 'pyproject.toml'
+      # - 'pyproject.toml'
 
 
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+  pull_request:
+    paths:
+      - '**.py'
+      - '.github/workflows/lint.yml'
+      - 'pyproject.toml'
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install ruff
+    - name: Analysing the code with pylint
+      run: |
+        ruff check $(git ls-files '*.py')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,4 +60,8 @@ packages = [
 pymdp = ['envs/assets/*']
 
 [tool.black]
-line-length = 120
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+ignore = ["E731"]


### PR DESCRIPTION
Adds a github action workflow to lint on PR and adds the required config to the pyproject.toml.

@conorheins @tverbele  I do not know how to test this. As it stands this will generate 120-ish warnings, which we can fix by running ruff check fix and committing that. I don't know if that is something we want to do now though.