### PR TITLE
Fixed param info gain computation and created tests - Fixes Issue #191

### DIFF
--- a/pymdp/maths.py
+++ b/pymdp/maths.py
@@ -12,13 +12,6 @@ from jax.experimental.sparse._base import JAXSparse
 
 MINVAL = jnp.finfo(float).eps
 
-# --- Toggle for information-gain formulation ---------------------------------
-# Set to ``True`` to use exact information-gain over parameters instead of the legacy
-# spm_wnorm heuristic.  Changing this single line lets you switch behaviour
-# globally without touching the rest of the code-base.
-USE_EXACT_PARAM_INFO_GAIN = True  # ⇦ CHANGE THIS LINE TO ``True`` FOR THE FIX
-# -----------------------------------------------------------------------------
-
 def stable_xlogx(x):
     return xlogy(x, jnp.clip(x, MINVAL))
 
@@ -197,16 +190,16 @@ def _exact_wnorm(A):
 
     return -wA # TODO: minus sign here gives negative info gain for backward compatibility with spm implementation. Later will need to remove minus sign here to get positive info gain and adjust function documentation accordingly.
 
-def spm_wnorm(A):
+def spm_wnorm(A, exact_param_info_gain=True):
     """
     Returns the weight matrix used in PyMDP's parameter information-gain term.
 
-    Historically this was the heuristic ``1/Σα − 1/α``. If the global flag
-    ``USE_EXACT_PARAM_INFO_GAIN`` is set to *True* we instead return the exact value of
-    the weight matrix used in the info gain computation defined in ``_exact_wnorm`` 
+    Historically this was the heuristic ``1/Σα − 1/α``. If exact_param_info_gain is set to *True* we instead return the exact value of
+    the weight matrix used in the info gain computation defined in _exact_wnorm 
     while keeping the original function signature so that the rest of the codebase remains unchanged.
     """
-    if USE_EXACT_PARAM_INFO_GAIN:
+
+    if exact_param_info_gain:
         return _exact_wnorm(A)
 
     """spm legacy heuristic for computing information-gain over parameters:

--- a/test/test_param_info_gain_jax.py
+++ b/test/test_param_info_gain_jax.py
@@ -1,0 +1,115 @@
+import pytest
+import jax.numpy as jnp
+import numpy as np
+from jax import grad
+from jax.scipy.special import digamma
+
+from pymdp.maths import _exact_wnorm
+
+
+@pytest.mark.parametrize("scale", [-12, -6, 0, 6, 12])
+def test_exact_wnorm_finite(scale):
+    """Ensure _exact_wnorm returns finite values and gradients across a wide range of magnitudes."""
+    # Matrix whose entries span many orders of magnitude; include an explicit zero.
+    base = jnp.array([
+        [0.0, 2.0, 3.0, 4.0],
+        [1.0, 5.0, 6.0, 0.5],
+        [7.0, 8.0, 9.0, 10.0],
+    ])
+    A = base * (10.0 ** scale)
+
+    # Forward computation
+    wA = _exact_wnorm(A)
+    assert jnp.all(jnp.isfinite(wA)), "_exact_wnorm produced NaN or Inf values"
+
+    # Backward computation (gradient wrt A)
+    grad_wA = grad(lambda x: _exact_wnorm(x).sum())(A)
+    assert jnp.all(jnp.isfinite(grad_wA)), "Gradient of _exact_wnorm produced NaN or Inf values" 
+
+
+def test_exact_wnorm_mathematical_correctness():
+    """Test _exact_wnorm with a simple case where we can verify the mathematical result."""
+    # Simple 2x2 case with known values
+    A = jnp.array([[1.0, 2.0],
+                   [3.0, 4.0]])
+    
+    result = _exact_wnorm(A)
+    
+    # Manually compute expected result using the formula
+    # wA = log(A.sum(0)) - log(A) + 1/A - 1/A.sum(0) + digamma(A) - digamma(A.sum(0))
+    A_sum = A.sum(axis=0)  # [4.0, 6.0]
+    
+    expected = (
+        jnp.log(A_sum) - jnp.log(A) +
+        1.0 / A - 1.0 / A_sum +
+        jnp.array(digamma(A)) - jnp.array(digamma(A_sum))
+    )
+    expected = -expected  # minus sign in the implementation
+    
+    np.testing.assert_allclose(result, expected, rtol=1e-6, atol=1e-8)
+    
+    # Verify output shape matches input
+    assert result.shape == A.shape 
+
+
+# -----------------------------------------------------------------------------
+# Test 3: Higher Dirichlet counts → lower expected information gain
+# -----------------------------------------------------------------------------
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 3, 42])
+def test_calc_pA_info_gain_precision(seed):
+    """Scaling Dirichlet counts upward (more precise prior) should *reduce* the magnitude of (negative) information gain."""
+    
+    import jax.random as jr
+    from pymdp.control import calc_pA_info_gain
+    
+    MINVAL = jnp.finfo(float).eps
+
+    # ---------------------------
+    # Shapes copied from T-Maze
+    # ---------------------------
+    num_obs = [5, 3, 3]   # observation dimensionalities per modality
+    num_states = [5, 2]   # hidden-state factor sizes
+    A_dependencies = [[0], [0, 1], [0, 1]]
+
+    # Build a dummy (uniform) observation model just to get shapes correct
+    A_like = [jnp.ones(shape) for shape in [
+        (5, 5),           # modality 0: 5×5
+        (3, 5, 2),        # modality 1: 3×5×2
+        (3, 5, 2)         # modality 2: 3×5×2
+    ]]
+
+    key_root = jr.PRNGKey(seed)
+    key_qs, key_qo, key_pA, key_scalar = jr.split(key_root, 4)
+
+    # Random posterior over hidden states (qs)
+    qs = []
+    for n, k in zip(num_states, jr.split(key_qs, len(num_states))):
+        probs = jr.uniform(k, (n,)) + MINVAL # ensure strictly positive
+        qs.append(probs / probs.sum())
+
+    # Random predictive beliefs over observations (qo)
+    qo = []
+    for n, k in zip(num_obs, jr.split(key_qo, len(num_obs))):
+        probs = jr.uniform(k, (n,)) + MINVAL
+        qo.append(probs / probs.sum())
+
+    # Random Dirichlet base counts (>0)
+    pA_uncertain = []
+    for a_like, k in zip(A_like, jr.split(key_pA, len(A_like))):
+        draw = jr.uniform(k, a_like.shape) * 2.0 + MINVAL  # counts in [MINVAL, MINVAL + 2.0)
+        pA_uncertain.append(draw)
+
+    # Slightly more precise prior
+    scalar = 1.0 + jr.uniform(key_scalar, ()) * 0.1  # factor in (1.0, 1.1]
+    pA_precise = [a * scalar for a in pA_uncertain]
+
+    # Negative information gain for each prior
+    neg_ig_uncertain = calc_pA_info_gain(pA_uncertain, qo, qs, A_dependencies)
+    neg_ig_precise = calc_pA_info_gain(pA_precise, qo, qs, A_dependencies)
+
+    # Remember: calc_pA_info_gain returns a *negative* quantity (due to historical sign convention).
+    # A larger (less negative) value corresponds to *lower* expected information gain.
+    assert neg_ig_precise > neg_ig_uncertain, "Increasing Dirichlet counts should make (negative) information gain less negative"
+    
+    


### PR DESCRIPTION
Addresses #191 

### Key improvements:
- Replaced the legacy heuristic with exact parameter information gain computation while maintaining backward compatibility and providing comprehensive test coverage.

## Summary of Changes

### 1. `pymdp/maths.py` changes:

- **Added imports**: `digamma` from `jax.scipy.special` 
- **New function `_exact_wnorm`**: Implements exact parameter info gain computation according to eq. (D.15) from Da Costa et al. (2020) with:
  - Single clipping strategy for numerical stability 
  - Direct use of `jnp.log()` and `digamma()` on clipped values
  - **Historical minus sign for backward compatibility**
- **Modified `spm_wnorm`**: 
  - Updated docstring to explain the exact vs legacy toggle
  - Added conditional logic to use `_exact_wnorm()` when `exact_param_info_gain` argument is set to `True`
  - Preserved legacy heuristic as fallback

### 2. New file `test/test_param_info_gain_jax.py` (115 lines):

- **`test_exact_wnorm_finite`**: Numerical stability test across extreme scales (1e-12 to 1e12)
- **`test_exact_wnorm_mathematical_correctness`**: Algebraic verification using hand-computed 2×2 example  
- **`test_calc_pA_info_gain_precision`**: Behavioral test verifying monotonic relationship between precision of beliefs and negative information gain using T-Maze dimensions, where precisions are randomized across 5 seeds