### PR TITLE
only construct flattened policies if policies is not set

### DIFF
--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -170,7 +170,7 @@ class Agent(Module):
         # flatten B action dims for multiple action dependencies
         self.action_maps = None
         if (
-            B_action_dependencies is not None
+            policies is None and B_action_dependencies is not None
         ):  # note, this only works when B_action_dependencies is not the trivial case of [[0], [1], ...., [num_factors-1]]
             policies_multi = control.construct_policies(
                 self.num_controls_multi,


### PR DESCRIPTION
currently, policies gets overridden when B_action_dependencies is not None, even when policies is not None