### PR TITLE
Fix/remove normalization check for p a and p b

### DIFF
--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -710,10 +710,6 @@ class Agent(Module):
                 assert (
                     self.pA[m].shape[2:] == factor_dims if self.pA[m] is not None else True
                 ), f"Please input an `A_dependencies` whose {m}-th indices correspond to the hidden state factors that line up with lagging dimensions of pA[{m}]..."
-                
-                # validate pA tensor is normalised, if it exists
-                if self.pA[m] is not None:
-                    utils.validate_normalization(self.pA[m], axis=1, tensor_name=f"pA[{m}]")
                     
             assert max(self.A_dependencies[m]) <= (
                 self.num_factors - 1
@@ -732,10 +728,6 @@ class Agent(Module):
                 assert (
                     self.pB[f].shape[2:-1] == factor_dims
                 ), f"Please input a `B_dependencies` whose {f}-th indices pick out the hidden state factors that line up with the all-but-final lagging dimensions of pB[{f}]..."
-                
-                # validate pB tensor is normalised, if it exists
-                if self.pB[f] is not None:
-                    utils.validate_normalization(self.pB[f], axis=1, tensor_name=f"pB[{f}]")
                     
             assert max(self.B_dependencies[f]) <= (
                 self.num_factors - 1

--- a/test/test_agent_jax.py
+++ b/test/test_agent_jax.py
@@ -418,6 +418,13 @@ class TestAgentJax(unittest.TestCase):
         # Should not raise; Agent.__init__ calls self._validate() which calls validate_normalization
         _ = Agent(A, B, A_dependencies=A_deps, B_dependencies=B_deps, num_controls=num_controls)
 
+        # also in presence of Dirichlet priors
+        pA = [10.0 * a for a in A]  # uniform Dirichlet priors
+        pB = [10.0 * b for b in B]
+
+        # Should not raise; Agent.__init__ calls self._validate() which calls validate_normalization
+        _ = Agent(A, B, A_dependencies=A_deps, B_dependencies=B_deps, num_controls=num_controls, pA=pA, pB=pB) 
+
     def test_agent_validate_normalization_raises_on_bad_A(self):
         """
         If A is not normalized along its outcome axis (axis=1 after broadcasting),
@@ -437,6 +444,12 @@ class TestAgentJax(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             _ = Agent(A_bad, B, A_dependencies=A_deps, B_dependencies=B_deps, num_controls=num_controls)
+        
+        # also raises in presence of Dirichlet priors
+        pA = [(10.0 * a + 1.0) for a in A_bad]  # uniform Dirichlet priors
+        pB = [(10.0 * b) for b in B]
+        with self.assertRaises(ValueError):
+            _ = Agent(A_bad, B, A_dependencies=A_deps, B_dependencies=B_deps, num_controls=num_controls, pA=pA, pB=pB)
 
     def test_agent_validate_normalization_raises_on_bad_B(self):
         """
@@ -457,6 +470,12 @@ class TestAgentJax(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             _ = Agent(A, B_bad, A_dependencies=A_deps, B_dependencies=B_deps, num_controls=num_controls)
+        
+        # also raises in presence of Dirichlet priors
+        pA = [10.0 * a for a in A]  # uniform Dirichlet priors
+        pB = [(10.0 * b + 1) for b in B_bad]
+        with self.assertRaises(ValueError):
+            _ = Agent(A, B_bad, A_dependencies=A_deps, B_dependencies=B_deps, num_controls=num_controls, pA=pA, pB=pB)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To address #232, removes normalization check for pA and pB in `Agent` since they are Dirichlet tensors, and also adds pA and pB into validation of normalization unit tests in `test/test_agent_jax.py`