### PR TITLE
Ensure correct behavior of `factors_to_update` argument in `pymdp/learning.py::update_state_transition_dirichlet()` 

### DIFF
--- a/pymdp/learning.py
+++ b/pymdp/learning.py
@@ -84,7 +84,7 @@ def update_state_transition_dirichlet(pB, B, joint_beliefs, actions, *, num_cont
        """ 
        Conditionally-update the Dirichlet posterior over a given single factor's B parameters
        Updating is conditional upon the value of `f`: if the factor index (f) is greater than -1, then use the value of f as the factor index
-       to create the appropriate one-hot representation of the action corresponding to the the f-th control factor and perform the update. Otherwise, do not perform t he update
+       to create the appropriate one-hot representation of the action corresponding to the the f-th control factor and perform the update. Otherwise, do not perform the update
        """
        qB_f, E_qB_f = lax.cond(
                 f>-1,

--- a/pymdp/learning.py
+++ b/pymdp/learning.py
@@ -84,8 +84,7 @@ def update_state_transition_dirichlet(pB, B, joint_beliefs, actions, *, num_cont
        """ 
        Conditionally-update the Dirichlet posterior over a given single factor's B parameters
        Updating is conditional upon the value of `f`: if the factor index (f) is greater than -1, then use the value of f as the factor index
-    to create the appropriate one-hot representation 
-       of the action corresponding to the the f-th control factor and perform the update. Otherwise, do not perform t he update
+       to create the appropriate one-hot representation of the action corresponding to the the f-th control factor and perform the update. Otherwise, do not perform t he update
        """
        qB_f, E_qB_f = lax.cond(
                 f>-1,
@@ -93,14 +92,9 @@ def update_state_transition_dirichlet(pB, B, joint_beliefs, actions, *, num_cont
                 lambda: (pB_f, dirichlet_expected_value(pB_f)),
             )
        return qB_f, E_qB_f
-        
-    # update_B_f_fn = lambda pB_f, joint_qs_f, f, na: None if pB_f is None else update_state_transition_dirichlet_f(
-    #     pB_f, actions_onehot_fn(f, na), joint_qs_f, lr=lr
-    # )
 
     if factors_to_update == 'all':
         factors_to_update_sorted = list(range(nf))
-        # factors_to_update_expanded = [True]*nf
     else:
         factors_to_update_sorted = [-1]*nf
         for f_i in sorted(factors_to_update):
@@ -110,17 +104,12 @@ def update_state_transition_dirichlet(pB, B, joint_beliefs, actions, *, num_cont
     result = tree_map(
         update_B_f_fn,
         pB, joint_beliefs, factors_to_update_sorted, num_controls,
-        # is_leaf=lambda x: x is None
     )
 
     qB = []
     E_qB = []
 
-    for i, r in enumerate(result):
-        # if r is None:
-        #     qB.append(None)
-        #     E_qB.append(B[i])
-        # else:
+    for r in result:
         qB.append(r[0])
         E_qB.append(r[1])
 

--- a/test/test_learning_jax.py
+++ b/test/test_learning_jax.py
@@ -313,61 +313,6 @@ class TestLearningJax(unittest.TestCase):
 
         action_jax = jnp.array([action])
 
-        # Method to apply the selective update without using the implemented way
-        pB_jax_update = [pB_jax[f] for f in factors_to_update]
-        belief_jax_update = [belief_jax[f] for f in factors_to_update]
-        action_jax_update = jnp.concatenate([action_jax[..., f : f + 1] for f in factors_to_update], axis=-1)
-        num_controls_update = [num_controls[f] for f in factors_to_update]
-
-        pB_updated_jax_factors, _ = update_pB_jax(
-            pB_jax_update, B, belief_jax_update, action_jax_update, num_controls=num_controls_update, lr=l_rate
-        )
-
-        pB_updated_jax = []
-        for f, _ in enumerate(num_states):
-            if f in factors_to_update:
-                pB_updated_jax.append(pB_updated_jax_factors[factors_to_update.index(f)])
-            else:
-                pB_updated_jax.append(pB_jax[f])
-
-        for pB_np, pB_jax in zip(pB_updated_numpy, pB_updated_jax):
-            self.assertTrue(pB_np.shape == pB_jax.shape)
-            self.assertTrue(np.allclose(pB_np, pB_jax))
-
-    @pytest.mark.skip("currently failing with error: ValueError: List arity mismatch: 2 != 3; list: [1, 2].")
-    def test_update_state_likelihood_multi_factor_some_factors_no_action_2(self):
-        """
-        Testing the JAXified version of updating Dirichlet posterior over transition likelihood parameters.
-        qB is the posterior, pB is the prior and B is the expectation of the likelihood wrt the
-        current posterior over B, i.e. $B = E_Q(B)[P(s_t | s_{t-1}, u_{t-1}, B)]$
-        """
-
-        num_states = [3, 4, 2]
-        num_controls = [3, 5, 5]
-        qs_prev = utils.random_single_categorical(num_states)
-        qs = utils.random_single_categorical(num_states)
-        l_rate = 1.0
-
-        B = utils.random_B_matrix(num_states, num_controls)
-        pB = utils.obj_array_ones([B_f.shape for B_f in B])
-
-        action = list(np.array([np.random.randint(c_dim) for c_dim in num_controls]))
-
-        factors_to_update = np.random.choice(list(range(len(B))), replace=False, size=(2,)).tolist()
-
-        pB_updated_numpy = update_pB_numpy(pB, B, action, qs, qs_prev, lr=l_rate, factors=factors_to_update)
-
-        belief_jax = []
-        for f in range(len(num_states)):
-            # Extract factor
-            q_f = jnp.array([qs[..., f].tolist()])
-            q_prev_f = jnp.array([qs_prev[..., f].tolist()])
-            belief_jax.append([q_f, q_prev_f])
-
-        pB_jax = [jnp.array(b) for b in pB]
-
-        action_jax = jnp.array([action])
-
         pB_updated_jax_factors, _ = update_pB_jax(
             pB_jax, B, belief_jax, action_jax, num_controls=num_controls, lr=l_rate, factors_to_update=factors_to_update
         )

--- a/test/test_learning_jax.py
+++ b/test/test_learning_jax.py
@@ -6,7 +6,6 @@ __author__: Dimitrije Markovic, Conor Heins
 """
 
 import unittest
-import pytest
 
 import numpy as np
 import jax.numpy as jnp


### PR DESCRIPTION
- fixes behavior of `update_state_transition_dirichlet()` in `pymdp.learning` to correctly handle the case when `factors_to_update` is a list of factor-specific indices that is less than the total set of factor indices
- removes skip of the previously-skipped test from #255 in `test/test_learning_jax.py` now that `update_state_transition_dirichlet()` is working with non-trivial settings of `factors_to_update` 