### PR TITLE
Enable running tests on chore/notebook pull requests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,6 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync
-      - name: Analysing the code with pylint
+      - name: Run tests
         run: |
           uv run pytest test


### PR DESCRIPTION
Github actions have to be added to the master branch to be picked up, even if they only apply to other branches