### PR TITLE
Update MCTS graph world notebook with latest batch_size= argument to `Agent` constructor

### DIFF
--- a/examples/experimental/sophisticated_inference/mcts_graph_world.ipynb
+++ b/examples/experimental/sophisticated_inference/mcts_graph_world.ipynb
@@ -170,7 +170,6 @@
     "    A_dependencies=A_dependencies,\n",
     "    B_dependencies=B_dependencies,\n",
     "    onehot_obs=False,\n",
-    "    apply_batch=False\n",
     ")"
    ]
   },


### PR DESCRIPTION
Addresses #264:

This removes `apply_batch=` argument from construction of agent in `examples/experimental/sophisticated_inference/mcts_graph_world.ipynb` notebook