### PR TITLE
fixed bug to select positions by dependency list indices

### DIFF
--- a/pymdp/envs/env.py
+++ b/pymdp/envs/env.py
@@ -12,8 +12,7 @@ def _float_to_int_index(x):
 
 def select_probs(positions, matrix, dependency_list, actions=None):
     # creating integer indices from float state positions for the positions specified in dependency_list
-    index_args = tuple(_float_to_int_index(p) for i, p in enumerate(positions) 
-                      if i in dependency_list)
+    index_args = tuple(_float_to_int_index(positions[i]) for i in dependency_list)
     if actions is not None:
         index_args += (_float_to_int_index(actions),)
     return matrix[(..., *index_args)]


### PR DESCRIPTION
Fixed `select_probs` function in `pymdp/envs/env.py` by changing `tuple(_float_to_int_index(p) for i, p in enumerate(positions) if i in dependency_list)` to `tuple(_float_to_int_index(positions[i]) for i in dependency_list)`. The original code was selecting position values in wrong order, and now it selects positions by dependency list indices in the correct order. I checked if the other notebooks in `examples/envs/` still run correctly with this change and they do.