### PR TITLE
fix: require pA for A matrix learning on Agent init

### DIFF
--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -140,6 +140,9 @@ class Agent(Module):
         if B_action_dependencies is not None:
             assert num_controls is not None, "Please specify num_controls if you're also using complex action dependencies"
 
+        if learn_A:
+            assert pA is not None, "pA is required for A learning"
+
         # extract high level variables
         self.num_modalities = len(A)
         self.num_factors = len(B)

--- a/test/test_agent_jax.py
+++ b/test/test_agent_jax.py
@@ -477,6 +477,20 @@ class TestAgentJax(unittest.TestCase):
         with self.assertRaises(ValueError):
             _ = Agent(A, B_bad, A_dependencies=A_deps, B_dependencies=B_deps, num_controls=num_controls, pA=pA, pB=pB)
 
+    def test_agent_with_A_learning_requires_pA(self):
+        """Test that creating an agent with learn_A=True 
+        but no pA raises an AssertionError."""
+        
+        num_obs = [1]
+        num_states = [1] 
+        num_controls = [1]
+
+        A = utils.random_A_matrix(num_obs, num_states)
+        B = utils.random_B_matrix(num_states, num_controls)
+
+        with self.assertRaises(AssertionError):
+            Agent(A=A, B=B, learn_A=True)
+        
 
 if __name__ == "__main__":
     unittest.main()       


### PR DESCRIPTION
Currently, it is possible to initialize an Agent with `learn_A` enabled but without providing `pA`. This results in an error at inference time, because priors are needed for learning.

This change raises an error if the user tries to create such an Agent, preventing an invalid state.

All tests passing here.

Addresses issue https://github.com/infer-actively/pymdp/issues/290