### PR TITLE
Add note in README about v1 alpha branch and JAX

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package is hosted on the [`infer-actively`](https://github.com/infer-active
 
 Most of the low-level mathematical operations are [NumPy](https://github.com/numpy/numpy) ports of their equivalent functions from the `SPM` [implementation](https://www.fil.ion.ucl.ac.uk/spm/doc/) in MATLAB. We have benchmarked and validated most of these functions against their SPM counterparts.
 
-⚠️ we are currently in the process of migrating `pymdp` to using [JAX](https://github.com/jax-ml/jax), as part of our roadmap for a v1 release of the package. For now, check out the `v1.0.0_alpha` branch for the best balance of new features and stability, although we intend to merge these features into the master branch as soon as possible.
+⚠️ We are currently in the process of migrating `pymdp` to a [JAX](https://github.com/jax-ml/jax) backend as part of our roadmap for a v1 release of the package. For now, check out the [`v1.0.0_alpha`](https://github.com/infer-actively/pymdp/tree/v1.0.0_alpha) branch for the best balance of new features and stability. We intend to merge these features into the master branch as soon as possible.
 
 ## Status
 


### PR DESCRIPTION
I had quite a few people talk to me at IWAI 2025 about using pymdp and JAX. I think it makes sense to have a little warning suggesting that they use the v1.0.0_alpha branch for now, and we can remove it once we merge v1 alpha into master