### PR TITLE
Add `utils.random_A_array` to replace `legacy.utils.random_A_matrix`

### DIFF
--- a/test/test_control_jax.py
+++ b/test/test_control_jax.py
@@ -15,7 +15,7 @@ import jax.tree_util as jtu
 import pymdp.control as ctl_jax
 import pymdp.legacy.control as ctl_np
 
-from pymdp.utils import random_factorized_categorical
+from pymdp.utils import random_factorized_categorical, random_A_array
 from pymdp.legacy import utils
 
 cfg = {"source_key": 0, "num_models": 4}
@@ -59,8 +59,8 @@ class TestControlJax(unittest.TestCase):
             qs_jax = random_factorized_categorical(keys_per_element[0], num_states)
             qs_numpy = utils.obj_array_from_list(qs_jax)
 
-            A_np = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_deps)
-            A_jax = jtu.tree_map(lambda x: jnp.array(x), list(A_np))   
+            A_jax = random_A_array(keys_per_element[1], num_obs, num_states, A_dependencies=A_deps)
+            A_np = [np.array(A_m) for A_m in A_jax]
 
             qo_test = ctl_jax.compute_expected_obs(qs_jax, A_jax, A_deps) 
             qo_validation = ctl_np.get_expected_obs_factorized([qs_numpy], A_np, A_deps) # need to wrap `qs` in list because `get_expected_obs_factorized` expects a list of `qs` (representing multiple timesteps)
@@ -129,8 +129,8 @@ class TestControlJax(unittest.TestCase):
             qs_jax = random_factorized_categorical(keys_per_element[0], num_states)
             qs_numpy = utils.obj_array_from_list(qs_jax)
 
-            A_np = utils.random_A_matrix(num_obs, num_states, A_factor_list=A_deps)
-            A_jax = jtu.tree_map(lambda x: jnp.array(x), list(A_np))   
+            A_jax = random_A_array(keys_per_element[1], num_obs, num_states, A_dependencies=A_deps)
+            A_np = [np.array(A_m) for A_m in A_jax]
 
             qo = ctl_jax.compute_expected_obs(qs_jax, A_jax, A_deps)
 

--- a/test/test_inference_jax.py
+++ b/test/test_inference_jax.py
@@ -11,7 +11,7 @@ import numpy as np
 from jax import numpy as jnp, random as jr
 
 from pymdp.algos import run_vanilla_fpi as fpi_jax
-from pymdp.utils import random_factorized_categorical
+from pymdp.utils import random_factorized_categorical, random_A_array
 
 from pymdp.legacy.algos import run_vanilla_fpi as fpi_numpy
 from pymdp.legacy import utils
@@ -39,23 +39,22 @@ class TestInferenceJax(unittest.TestCase):
         keys = jr.split(jr.PRNGKey(42), len(num_states_list)*2).reshape((len(num_states_list), 2, 2))
         for (keys_per_element, num_states, num_obs) in zip(keys, num_states_list, num_obs_list):
             
-            # jax version of prior
+            # jax arrays
             prior_jax = random_factorized_categorical(keys_per_element[0], num_states)
-            # numpy version
+            A_jax = random_A_array(keys_per_element[1], num_obs, num_states)
+
+            # numpy arrays
             prior = utils.obj_array_from_list(prior_jax)
-            A = utils.random_A_matrix(num_obs, num_states)
+            A_np = utils.obj_array_from_list(A_jax)
 
             obs = utils.obj_array(len(num_obs))
             for m, obs_dim in enumerate(num_obs):
                 obs[m] = utils.onehot(np.random.randint(obs_dim), obs_dim)
 
-            qs_numpy = fpi_numpy(A, obs, num_obs, num_states, prior=prior, num_iter=16, dF=1.0, dF_tol=-1.0) # set dF_tol to negative number so numpy version of FPI never stops early due to convergence
+            qs_numpy = fpi_numpy(A_np, obs, num_obs, num_states, prior=prior, num_iter=16, dF=1.0, dF_tol=-1.0) # set dF_tol to negative number so numpy version of FPI never stops early due to convergence
 
-            # jax version
-            A = [jnp.array(a_m) for a_m in A]
             obs = [jnp.array(o_m) for o_m in obs]
-
-            qs_jax = fpi_jax(A, obs, prior_jax, num_iter=16)
+            qs_jax = fpi_jax(A_jax, obs, prior_jax, num_iter=16)
 
             for f, _ in enumerate(qs_jax):
                 self.assertTrue(np.allclose(qs_numpy[f], qs_jax[f]))
@@ -81,22 +80,23 @@ class TestInferenceJax(unittest.TestCase):
         keys = jr.split(jr.PRNGKey(43), len(num_states_list)*2).reshape((len(num_states_list), 2, 2))
         for (keys_per_element, num_states, num_obs) in zip(keys, num_states_list, num_obs_list):
 
-            # numpy version
+            # jax arrays
             prior_jax = random_factorized_categorical(keys_per_element[0], num_states)
+            A_jax = random_A_array(keys_per_element[1], num_obs, num_states)
+
+            # numpy arrays
             prior = utils.obj_array_from_list(prior_jax)
-            A = utils.random_A_matrix(num_obs, num_states)
+            A_np = utils.obj_array_from_list(A_jax)
 
             obs = utils.obj_array(len(num_obs))
             for m, obs_dim in enumerate(num_obs):
                 obs[m] = utils.onehot(np.random.randint(obs_dim), obs_dim)
 
-            qs_numpy = fpi_numpy(A, obs, num_obs, num_states, prior=prior, num_iter=16, dF=1.0, dF_tol=-1.0) # set dF_tol to negative number so numpy version of FPI never stops early due to convergence
+            qs_numpy = fpi_numpy(A_np, obs, num_obs, num_states, prior=prior, num_iter=16, dF=1.0, dF_tol=-1.0) # set dF_tol to negative number so numpy version of FPI never stops early due to convergence
 
-            # jax version
-            A = [jnp.array(a_m) for a_m in A]
             obs = [jnp.array(o_m) for o_m in obs]
 
-            qs_jax = fpi_jax(A, obs, prior_jax, num_iter=16)
+            qs_jax = fpi_jax(A_jax, obs, prior_jax, num_iter=16)
 
             for f, _ in enumerate(qs_jax):
                 self.assertTrue(np.allclose(qs_numpy[f], qs_jax[f]))
@@ -121,23 +121,23 @@ class TestInferenceJax(unittest.TestCase):
 
         keys = jr.split(jr.PRNGKey(44), len(num_states_list)*2).reshape((len(num_states_list), 2, 2))
         for (keys_per_element, num_states, num_obs) in zip(keys, num_states_list, num_obs_list):
+            
+            # jax arrays
+            prior_jax = random_factorized_categorical(keys_per_element[0], num_states)
+            A_jax = random_A_array(keys_per_element[1], num_obs, num_states)
 
             # numpy version
-            prior_jax = random_factorized_categorical(keys_per_element[0], num_states)
             prior = utils.obj_array_from_list(prior_jax)
-            A = utils.random_A_matrix(num_obs, num_states)
+            A_np = utils.obj_array_from_list(A_jax)
 
             obs = utils.obj_array(len(num_obs))
             for m, obs_dim in enumerate(num_obs):
                 obs[m] = utils.onehot(np.random.randint(obs_dim), obs_dim)
 
-            qs_numpy = fpi_numpy(A, obs, num_obs, num_states, prior=prior, num_iter=16, dF=1.0, dF_tol=-1.0) # set dF_tol to negative number so numpy version of FPI never stops early due to convergence
+            qs_numpy = fpi_numpy(A_np, obs, num_obs, num_states, prior=prior, num_iter=16, dF=1.0, dF_tol=-1.0) # set dF_tol to negative number so numpy version of FPI never stops early due to convergence
 
-            # jax version
-            A = [jnp.array(a_m) for a_m in A]
             obs = [jnp.array(o_m) for o_m in obs]
-
-            qs_jax = fpi_jax(A, obs, prior_jax, num_iter=16)
+            qs_jax = fpi_jax(A_jax, obs, prior_jax, num_iter=16)
 
             for f, _ in enumerate(qs_jax):
                 self.assertTrue(np.allclose(qs_numpy[f], qs_jax[f]))
@@ -166,23 +166,24 @@ class TestInferenceJax(unittest.TestCase):
 
         keys = jr.split(jr.PRNGKey(45), len(num_states_list)*2).reshape((len(num_states_list), 2, 2))
         for (keys_per_element, num_states, num_obs) in zip(keys, num_states_list, num_obs_list):
-
-            # numpy version
+            
+            # jax arrays
             prior_jax = random_factorized_categorical(keys_per_element[0], num_states)
+            A_jax = random_A_array(keys_per_element[1], num_obs, num_states)
+                
+            # numpy arrays
             prior = utils.obj_array_from_list(prior_jax)
-            A = utils.random_A_matrix(num_obs, num_states)
+            A_np = utils.obj_array_from_list(A_jax)
 
             obs = utils.obj_array(len(num_obs))
             for m, obs_dim in enumerate(num_obs):
                 obs[m] = utils.onehot(np.random.randint(obs_dim), obs_dim)
 
-            qs_numpy = fpi_numpy(A, obs, num_obs, num_states, prior=prior, num_iter=16, dF=1.0, dF_tol=-1.0) # set dF_tol to negative number so numpy version of FPI never stops early due to convergence
+            qs_numpy = fpi_numpy(A_np, obs, num_obs, num_states, prior=prior, num_iter=16, dF=1.0, dF_tol=-1.0) # set dF_tol to negative number so numpy version of FPI never stops early due to convergence
 
             # jax version
-            A = [jnp.array(a_m) for a_m in A]
             obs = [jnp.array(o_m) for o_m in obs]
-
-            qs_jax = fpi_jax(A, obs, prior_jax, num_iter=16)
+            qs_jax = fpi_jax(A_jax, obs, prior_jax, num_iter=16)
 
             for f, _ in enumerate(qs_jax):
                 self.assertTrue(np.allclose(qs_numpy[f], qs_jax[f]))
@@ -212,27 +213,26 @@ class TestInferenceJax(unittest.TestCase):
 
         keys = jr.split(jr.PRNGKey(46), len(num_states_list)*2).reshape((len(num_states_list), 2, 2))
         for (keys_per_element, num_states, num_obs) in zip(keys, num_states_list, num_obs_list):
-
-            # numpy version
+            
+            # jax arrays
+            A_jax = random_A_array(keys_per_element[1], num_obs, num_states)
             prior_jax = random_factorized_categorical(keys_per_element[0], num_states)
+
+            # numpy arrays
             prior = utils.obj_array_from_list(prior_jax)
-            A = utils.random_A_matrix(num_obs, num_states)
+            A_np = utils.obj_array_from_list(A_jax)
 
             obs = utils.obj_array(len(num_obs))
             for m, obs_dim in enumerate(num_obs):
                 obs[m] = utils.onehot(np.random.randint(obs_dim), obs_dim)
 
-            qs_numpy = fpi_numpy(A, obs, num_obs, num_states, prior=prior, num_iter=16, dF=1.0, dF_tol=-1.0) # set dF_tol to negative number so numpy version of FPI never stops early due to convergence
+            qs_numpy = fpi_numpy(A_np, obs, num_obs, num_states, prior=prior, num_iter=16, dF=1.0, dF_tol=-1.0) # set dF_tol to negative number so numpy version of FPI never stops early due to convergence
 
             obs_idx = []
             for ob in obs:
                 obs_idx.append(np.where(ob)[0][0])
             
-            # jax version
-            A = [jnp.array(a_m) for a_m in A]
-            # obs = [jnp.array(o_m) for o_m in obs]
-
-            qs_jax = fpi_jax(A, obs_idx, prior_jax, num_iter=16, distr_obs=False)
+            qs_jax = fpi_jax(A_jax, obs_idx, prior_jax, num_iter=16, distr_obs=False)
 
             for f, _ in enumerate(qs_jax):
                 self.assertTrue(np.allclose(qs_numpy[f], qs_jax[f]))

--- a/test/test_rollout_function.py
+++ b/test/test_rollout_function.py
@@ -14,7 +14,7 @@ from pymdp.legacy import utils
 from pymdp.agent import Agent
 from pymdp.envs.env import Env
 from pymdp.envs.rollout import rollout, default_policy_search
-from pymdp.utils import random_factorized_categorical
+from pymdp.utils import random_factorized_categorical, random_A_array, list_array_scaled
 
 class TestRolloutFunction(unittest.TestCase):
     def setUp(self):
@@ -38,13 +38,11 @@ class TestRolloutFunction(unittest.TestCase):
         
         A_key, B_key, D_key = jr.split(jr.PRNGKey(seed), 3)
 
-        A = utils.random_A_matrix(
-            self.num_obs, self.num_states, A_factor_list=self.A_dependencies
-        )
+        A = random_A_array(A_key, self.num_obs, self.num_states, A_dependencies=self.A_dependencies)
         B = utils.random_B_matrix(
             self.num_states, self.num_controls, B_factor_list=self.B_dependencies
         )
-        pA = utils.dirichlet_like(A, scale=1.0)
+        pA = list_array_scaled([a.shape for a in A], scale=1.0)
         pB = utils.dirichlet_like(B, scale=1.0)
         D = random_factorized_categorical(D_key, self.num_states)
 


### PR DESCRIPTION
### Summary
Addresses #305
This PR adds `random_A_array` function to create factorized observation likelihoods as jax arrays and replaces usage of deprecated `legacy.utils.random_A_matrix` throughout the repository.

This involved:
- adding tests for `random_A_array` to validate shape and normalization of outputs, and default behavior of case when `A_dependencies=None`
- adding `make_A_full` function to construct a full A matrix from a reduced version and dependencies to `utils`
- replacing usage of `legacy.utils.random_A_matrix` with jax-based `utils.random_A_array` throughout unit tests