### PR TITLE
fix: do not vmap `generate_I_matrix` over `self.inductive_depth` in `self.infer_parameters()` of `Agent`

### DIFF
--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -464,7 +464,7 @@ class Agent(Module):
             )
             # if you have updated your beliefs about transitions, you need to re-compute the I matrix used for inductive inferenece
             if self.use_inductive and self.H is not None:
-                I_updated = vmap(control.generate_I_matrix)(self.H, E_qB, self.inductive_threshold, self.inductive_depth)
+                I_updated = vmap(partial(control.generate_I_matrix, depth=self.inductive_depth))(self.H, E_qB, self.inductive_threshold)
                 agent = tree_at(lambda x: (x.B, x.pB, x.I), agent, (E_qB, qB, I_updated))
             else:
                 agent = tree_at(lambda x: (x.B, x.pB), agent, (E_qB, qB))


### PR DESCRIPTION
### Summary
Bugfix to address #303: update inductive matrix computation in Agent class in case when `learn_B=True` so that `pymdp.control.generate_I_matrix` is not `vmap`ed over the static argument `self.inductive_depth`, which is fixed as a function of the agent batch

#### Testing
- add unit test to ensure inductive matrix is as expected after learning in `test/test_agent_jax.py`

Thanks to @KKidera for spotting this