### PR TITLE
Add automated test for api notebooks to CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,4 +32,4 @@ jobs:
           uv run pytest test
       - name: Running notebook tests
         run: |
-          uv run pytest --nbval examples/api/
+          uv run pytest --nbval-lax examples/api/


### PR DESCRIPTION
Addresses https://github.com/infer-actively/pymdp/issues/322

This change adds running the `examples/api` notebooks to our CI. This is done separately to the unit tests because incoming speed optimisations for running unit tests vs notebook tests will likely be very different 

There is only a single notebook and the test runs pretty [quickly](https://github.com/infer-actively/pymdp/actions/runs/19574811497/job/56057194663?pr=321) (adds ~15s in total to CI times )