### PR TITLE
make `Agent` methods `decode_multi_actions` and ` encode_multi_actions` JIT-able

### DIFF
--- a/pymdp/utils.py
+++ b/pymdp/utils.py
@@ -234,7 +234,7 @@ def index_to_combination(index, dims):
         x.append(index % base)
         index = index // base
 
-    x = np.flip(np.stack(x, axis=-1), axis=-1)
+    x = jnp.flip(jnp.stack(x, axis=-1), axis=-1)
     return x
 
 def make_A_full(A_reduced: List[jax.Array], A_dependencies: List[List[int]], num_obs: List[int], num_states: List[int]) -> List[jax.Array]:


### PR DESCRIPTION
This PR addresses #324

- small change to `pymdp.utils.index_to_combination` to use jax.numpy instead of numpy for JIT-compatbility with its use in `pymdp.agent.Agent.decode_multi_actions`
- adds unit test to `test_agent_complex_action` in `test_agent_jax.py` to ensure that `decode_multi_actions`  and `encode_multi_actions`  can get jitted