### PR TITLE
Add support for categorical obs in Env to fix rollout

### DIFF
--- a/pymdp/envs/generalized_tmaze.py
+++ b/pymdp/envs/generalized_tmaze.py
@@ -504,7 +504,7 @@ class GeneralizedTMazeEnv(Env):
     similar to the original T-maze.
     """
 
-    def __init__(self, env_info, batch_size=1):
+    def __init__(self, env_info, batch_size=1, categorical_obs=False):
         A, A_dependencies = generate_A(env_info)
         B, B_dependencies = generate_B(env_info)
         D = generate_D(env_info)
@@ -516,7 +516,7 @@ class GeneralizedTMazeEnv(Env):
         }
         dependencies = {"A": A_dependencies, "B": B_dependencies}
 
-        Env.__init__(self, params, dependencies)
+        Env.__init__(self, params, dependencies, categorical_obs=categorical_obs)
 
     def render(self, mode="human"):
         """

--- a/pymdp/envs/graph_worlds.py
+++ b/pymdp/envs/graph_worlds.py
@@ -26,7 +26,7 @@ class GraphEnv(Env):
     The agent observes its own location, as well as whether the object is at its location.
     """
 
-    def __init__(self, graph: nx.Graph, object_locations: list[int], agent_locations: list[int]):
+    def __init__(self, graph: nx.Graph, object_locations: list[int], agent_locations: list[int], categorical_obs: bool = False):
         batch_size = len(object_locations)
 
         A, A_dependencies = self.generate_A(graph)
@@ -46,7 +46,7 @@ class GraphEnv(Env):
             "B": B_dependencies,
         }
 
-        super().__init__(params, dependencies)
+        super().__init__(params, dependencies, categorical_obs=categorical_obs)
 
     def generate_A(self, graph: nx.Graph):
         A = []

--- a/pymdp/envs/grid_world.py
+++ b/pymdp/envs/grid_world.py
@@ -76,6 +76,7 @@ class GridWorld(Env):
         include_stay: bool = True,
         success_prob: float = 1.0,
         batch_size: int = 1,
+        categorical_obs: bool = False,
     ):
         rows, cols = shape
         assert rows >= 1 and cols >= 1, "Grid shape must be positive."
@@ -99,7 +100,7 @@ class GridWorld(Env):
         }
         dependencies = {"A": A_deps, "B": B_deps}
 
-        super().__init__(params, dependencies)
+        super().__init__(params, dependencies, categorical_obs=categorical_obs)
 
     # ---------------------------------------------------------------------
     # Optional convenience accessors (not required by the API)

--- a/pymdp/envs/tmaze.py
+++ b/pymdp/envs/tmaze.py
@@ -35,7 +35,16 @@ class TMaze(Env):
     reward_condition: float = field(static=True)
     dependent_outcomes: bool = field(static=True)
 
-    def __init__(self, batch_size=1, reward_probability=1.0, punishment_probability=1.0, cue_validity=0.95, reward_condition=None, dependent_outcomes=False):
+    def __init__(
+            self, 
+            batch_size=1, 
+            reward_probability=1.0, 
+            punishment_probability=1.0, 
+            cue_validity=0.95, 
+            reward_condition=None, 
+            dependent_outcomes=False, 
+            categorical_obs=False,
+        ):
         """
         Initialize T-Maze environment. A is the observation likelihood matrix, B is the transition matrix, D is the initial state distribution.
         Args:
@@ -45,6 +54,7 @@ class TMaze(Env):
             cue_validity: Probability of cue correctly indicating reward location
             reward_condition: If specified, fixes reward to left (0) or right (1) arm, otherwise reward is randomly assigned
             dependent_outcomes: If True, punishment occurs as a function of reward probability (i.e., if reward probability is 0.8, then 20% punishment). If False, punishment occurs with set probability (i.e., 20% no outcome and punishment will only occur in the other (non-rewarding) arm)
+            categorical_obs: If True, return observations as a probability distribution instead of a discrete sample
         """
         self.reward_probability = reward_probability
         self.punishment_probability = punishment_probability
@@ -67,11 +77,11 @@ class TMaze(Env):
         }
 
         dependencies = { # specifying which matrix is dependent on which state factors allows you to not have to specify all combinations of state factors in the matrix
-            "A": A_dependencies, 
+            "A": A_dependencies,
             "B": B_dependencies,
         }
 
-        super().__init__(params, dependencies)
+        super().__init__(params, dependencies, categorical_obs=categorical_obs)
 
     def generate_A(self):
         """

--- a/test/test_rollout_function.py
+++ b/test/test_rollout_function.py
@@ -12,6 +12,7 @@ import jax.tree_util as jtu
 
 from pymdp.agent import Agent
 from pymdp.envs.env import Env
+from pymdp.envs import TMaze
 from pymdp.envs.rollout import rollout, default_policy_search
 from pymdp import utils
 
@@ -283,6 +284,27 @@ class TestRolloutFunction(unittest.TestCase):
         self.assertTrue(jnp.allclose(learned_pB, expected_pB, atol=1e-5))
         self.assertTrue(jnp.allclose(learned_B, expected_B, atol=1e-5))
 
+    def test_rollout_with_categorical_obs(self):
+        key = jr.PRNGKey(0)
+        batch_size=1
+        T = 5
+        env = TMaze(
+            batch_size=batch_size,
+            categorical_obs=True,
+        )
+        A, A_dependencies = env.generate_A()
+        B, B_dependencies = env.generate_B()
+        agent = Agent(
+            A=A,
+            B=B,
+            A_dependencies=A_dependencies,
+            B_dependencies=B_dependencies,
+            batch_size=batch_size,
+            policy_len=T,
+            categorical_obs=True,
+        )
+        _, info, _ = rollout(agent, env, num_timesteps=T, rng_key=key)
+        self.assertIsNotNone(info)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Addresses https://github.com/infer-actively/pymdp/issues/277 by allowing the Env class to output a categorical distribution for observations

This PR is stacked on top of https://github.com/infer-actively/pymdp/pull/326 which should be reviewed and landed first