### PR TITLE
Add unit test coverage report to github CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,9 +27,17 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync --group test
-      - name: Running unit tests
+      - name: Running unit tests with coverage
         run: |
-          uv run pytest test -n 2
+          uv run pytest test -n 2 --cov=pymdp --cov-report=xml --cov-report=html --cov-report=term
+      - name: Upload coverage reports as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: v1.0.0_alpha-coverage
+          path: |
+            coverage.xml
+            htmlcov/
+          retention-days: 30
       - name: Running notebook tests
         run: |
           uv run pytest --nbval-lax examples/api/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ venv/
 .venv
 .jax_cache
 .ruff_cache
+.coverage
+coverage.xml
+htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
     "nbval>=0.11.0",
     "pybefit",
     "pygraphviz>=1.14",
+    "pytest-cov>=7.0.0",
     "pytest>=8.4.2",
     "pytest-timeout>=2.4.0",
     "pytest-xdist>=3.5.0",
@@ -98,6 +99,18 @@ filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::FutureWarning",
 ]
+
+[tool.coverage.run]
+source = ["pymdp"]
+omit = [
+    "*/test/*",
+    "pymdp/legacy/*",
+]
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+skip_covered = false
 
 [tool.uv.sources]
 pybefit = { git = "https://github.com/conorheins/pybefit.git", rev = "fix/pymdp-compat" }


### PR DESCRIPTION
Addresses https://github.com/infer-actively/pymdp/issues/142

This change adds test coverage reports, inspired by https://github.com/infer-actively/pymdp/pull/140, but doing it in a way that is compatible with running unit tests concurrently (pytest-xidst).

Example output in CI:

```
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.12.12-final-0 _______________
Name                              Stmts   Miss   Cover   Missing
----------------------------------------------------------------
pymdp/__init__.py                     0      0 100.00%
pymdp/agent.py                      387     71  81.65%   191, 221-225, 227, 241-245, 247, 286-288, 310-318, 323-326, 355, 378, 421-440, 566-568, 662-665, 689, 692-693, 703, 717, 736, 752, 759, 779, 789, 819-834
pymdp/algos.py                      253     41  83.79%   152-177, 182-210, 231, 240-241, 245-246, 249-250, 349-350, 469-481
pymdp/control.py                    169     59  65.09%   38-45, 74-84, 90-92, 127, 130, 145-155, 177-184, 221, 281-286, 291-314, 441-455
pymdp/distribution.py               234     65  72.22%   24-29, 63, 91, 99, 106, 109, 129-133, 136, 167, 306, 314-325, 331-427
pymdp/envs/__init__.py                5      0 100.00%
pymdp/envs/env.py                    65      5  92.31%   24-27, 69, 84
pymdp/envs/generalized_tmaze.py     196    196   0.00%   1-535
pymdp/envs/graph_worlds.py           73     64  12.33%   8-15, 30-49, 52-81, 84-109, 112-126
pymdp/envs/grid_world.py             92     17  81.52%   110, 115, 126-131, 199-200, 227-233, 236
pymdp/envs/rollout.py                69      1  98.55%   40
pymdp/envs/tmaze.py                 183    155  15.30%   49-74, 89-138, 150-186, 201-214, 217-380
pymdp/inference.py                   61      6  90.16%   36-41, 74-82
pymdp/learning.py                    46      2  95.65%   75-76
pymdp/likelihoods.py                 27     27   0.00%   1-44
pymdp/maths.py                      157     51  67.52%   23, 51-55, 61-77, 137-144, 157-165, 207-212, 257-260, 266, 279, 290-291, 301-306
pymdp/utils.py                      273     36  86.81%   144, 266-273, 378-428, 457-465, 529, 564-565, 672-674
----------------------------------------------------------------
TOTAL                              2290    796  65.24%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
================= 180 passed, 4 warnings in 281.01s (0:04:41) ==================
```

Example download [link](https://github.com/infer-actively/pymdp/actions/runs/20106269952/artifacts/4827213912) of html coverage report.

Both outputs can be found when clicking into a build job on pymdp (currently only for v1.0.0_alpha branch) 