### PR TITLE
Speed up unit tests and move long HMM stability case to nightly

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -1,0 +1,33 @@
+name: Nightly Tests
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v1.0.0_alpha
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz-dev
+      - name: Install dependencies
+        run: |
+          uv sync --group test
+      - name: Running nightly-marked tests
+        run: |
+          uv run pytest test -n 2 -m nightly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
           uv sync --group test
       - name: Running unit tests with coverage
         run: |
-          uv run pytest test -n 2 --cov=pymdp --cov-report=xml --cov-report=html --cov-report=term
+          uv run pytest test -n 2 -m "not nightly" --cov=pymdp --cov-report=xml --cov-report=html --cov-report=term
       - name: Upload coverage reports as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ venv/
 coverage.xml
 htmlcov/
 site/
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,9 @@ filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::FutureWarning",
 ]
+markers = [
+    "nightly: long-running tests executed in nightly CI",
+]
 
 [tool.coverage.run]
 source = ["pymdp"]

--- a/test/test_agent_jax.py
+++ b/test/test_agent_jax.py
@@ -373,9 +373,9 @@ class TestAgentJax(unittest.TestCase):
         """
         Test that an instance of the `Agent` class can be initialized and run with complex action dependency
         """
-        num_obs = [5, 4, 4]
-        num_states = [2, 3, 1]
-        num_controls = [2, 3, 2]
+        num_obs = [3, 3, 2]
+        num_states = [2, 2, 1]
+        num_controls = [2, 2, 2]
 
         a_key, b_key, action_key, obs_key = jr.split(jr.PRNGKey(5), 4)
 
@@ -414,9 +414,9 @@ class TestAgentJax(unittest.TestCase):
         def construct_and_run_agent(a_key, b_key, obs_key, action_key):
             """
             Test that an instance of the `Agent` class can be initialized and run with complex action dependency
-            num_obs = [5, 4, 4]
-            num_states = [2, 3, 1]
-            num_controls = [2, 3, 2]
+            num_obs = [3, 3, 2]
+            num_states = [2, 2, 1]
+            num_controls = [2, 2, 2]
             """
 
             A = utils.random_A_array(a_key, num_obs, num_states, A_dependencies=A_dependencies)
@@ -554,12 +554,12 @@ class TestAgentJax(unittest.TestCase):
         """
         Test that the constructor call of the Agent class is jittable
         """
-        num_obs = [3, 4]
-        num_states = [4, 5, 6]
-        num_controls = [2, 3, 1]
+        num_obs = [2, 3]
+        num_states = [3, 4, 4]
+        num_controls = [2, 2, 1]
         A_dependencies = [[0], [0, 1, 2]]
         B_dependencies = [[0], [1], [2]]
-        batch_size = 2
+        batch_size = 1
 
         a_key, b_key, d_key = jr.split(jr.PRNGKey(123), 3)
 
@@ -672,12 +672,12 @@ class TestAgentJax(unittest.TestCase):
         and computation of multi-action log-probabilities.
         """
 
-        num_obs = [3, 4]
-        num_states = [4, 5, 6]
-        num_controls = [2, 3, 1]
+        num_obs = [2, 3]
+        num_states = [3, 4, 4]
+        num_controls = [2, 2, 1]
         A_dependencies = [[0], [0, 1, 2]]
         B_dependencies = [[0], [1], [2]]
-        batch_size = 2
+        batch_size = 1
 
         a_key, b_key, d_key = jr.split(jr.PRNGKey(123), 3)
 

--- a/test/test_hmm_associative_scan.py
+++ b/test/test_hmm_associative_scan.py
@@ -4,6 +4,7 @@
 """Tests for associative-scan HMM filtering/smoothing."""
 
 import unittest
+import pytest
 from jax import numpy as jnp, random as jr, nn
 from jax import vmap, grad
 from jax import tree_util as jtu
@@ -397,10 +398,11 @@ class TestAssociativeScanHMM(unittest.TestCase):
         self._assert_close(xi_row, xi_col)
         self._assert_close(cond_row, cond_col)
 
+    @pytest.mark.nightly
     def test_smoother_scan_colstoch_stability_shifted_ll(self):
         key = jr.PRNGKey(6)
         initial_probs, B_mats, log_likelihoods = self._make_case_col(
-            key, T=100, K=100, time_varying=True
+            key, T=100, K=48, time_varying=True
         )
         log_likelihoods = log_likelihoods - 100.0
 
@@ -469,7 +471,7 @@ class TestAssociativeScanHMM(unittest.TestCase):
 
     def test_gradients_finite_rowstoch_smoother(self):
         key = jr.PRNGKey(11)
-        T, K = 24, 24
+        T, K = 16, 16
         k1, k2, k3 = jr.split(key, 3)
         pi_logits = jr.normal(k1, (K,))
         trans_logits = jr.normal(k2, (K, K))
@@ -503,7 +505,7 @@ class TestAssociativeScanHMM(unittest.TestCase):
 
     def test_gradients_finite_colstoch_smoother(self):
         key = jr.PRNGKey(12)
-        T, K = 24, 24
+        T, K = 16, 16
         k1, k2, k3 = jr.split(key, 3)
         pi_logits = jr.normal(k1, (K,))
         B_logits = jr.normal(k2, (K, K))
@@ -539,7 +541,7 @@ class TestAssociativeScanHMM(unittest.TestCase):
 
     def test_strict_zero_absorbing_transitions_finite_outputs_and_grads(self):
         key = jr.PRNGKey(14)
-        T, K = 40, 14
+        T, K = 24, 10
         ll_logits = jr.normal(key, (T, K)) * 3.0 - 80.0
         ll = nn.log_softmax(ll_logits, axis=-1)
 
@@ -589,7 +591,7 @@ class TestAssociativeScanHMM(unittest.TestCase):
 
     def test_near_zero_transitions_finite_outputs_and_grads(self):
         key = jr.PRNGKey(15)
-        T, K = 24, 20
+        T, K = 16, 12
         k1, k2 = jr.split(key, 2)
         ll_logits = jr.normal(k1, (T, K)) * 4.0 - 120.0
         ll = nn.log_softmax(ll_logits, axis=-1)
@@ -639,7 +641,7 @@ class TestAssociativeScanHMM(unittest.TestCase):
 
     def test_directional_derivative_rowstoch_filter_mll(self):
         key = jr.PRNGKey(13)
-        T, K = 12, 8
+        T, K = 10, 6
         n_pi = K
         n_trans = K * K
         n_ll = T * K
@@ -663,7 +665,7 @@ class TestAssociativeScanHMM(unittest.TestCase):
 
         # Check sampled directional derivatives against central finite differences.
         eps = 1e-3
-        n_dirs = 3
+        n_dirs = 2
         dir_keys = jr.split(jr.PRNGKey(101), n_dirs)
         for dkey in dir_keys:
             v = jr.normal(dkey, theta0.shape)

--- a/test/test_infer_states_optimized.py
+++ b/test/test_infer_states_optimized.py
@@ -69,7 +69,7 @@ class TestInferStatesComparison(unittest.TestCase):
         parameter_sets = [
             (5, 5, 5, 5, 'uniform', 'low'),
             (10, 10, 10, 10, 'uniform', 'medium'),
-            (25, 25, 25, 25, 'uniform', 'high'),
+            (18, 18, 18, 18, 'uniform', 'high'),
             # (125, 125, 125, 125, 'uniform', 'extreme'),  # Uncomment to include extreme cases
         ]
 
@@ -309,7 +309,7 @@ class TestInferStatesComparison(unittest.TestCase):
         """Test that batch size method works with different batch sizes."""
         spec = self.AGENT_SPECS[0]  # Use first spec
 
-        for batch_size in [1, 2, 4, 8]:
+        for batch_size in [1, 4]:
             with self.subTest(batch_size=batch_size):
                 self._test_single_spec_with_batch(spec, batch_size=batch_size)
 

--- a/test/test_message_passing_jax.py
+++ b/test/test_message_passing_jax.py
@@ -23,7 +23,7 @@ from pymdp.legacy import utils
 
 from typing import List, Dict
 
-def make_model_configs(source_seed=0, num_models=4) -> Dict:
+def make_model_configs(source_seed=0, num_models=3) -> Dict:
     rng_keys = jr.split(jr.PRNGKey(source_seed), num_models)
     num_factors_list = [ jr.randint(key, (1,), 1, 7)[0].item() for key in rng_keys ] # list of total numbers of hidden state factors per model
     num_states_list = [ jr.randint(key, (nf,), 2, 5).tolist() for nf, key in zip(num_factors_list, rng_keys) ]
@@ -59,7 +59,7 @@ class TestMessagePassing(unittest.TestCase):
 
     def test_fixed_point_iteration(self):
         cfg = {'source_seed': 0,
-                'num_models': 4
+                'num_models': 3
             }
         gm_params = make_model_configs(**cfg)
         num_states_list, num_obs_list = gm_params['ns_list'], gm_params['no_list']
@@ -92,7 +92,7 @@ class TestMessagePassing(unittest.TestCase):
         with multiple hidden state factors and multiple observation modalities.
         """
         cfg = {'source_seed': 1,
-                'num_models': 4
+                'num_models': 3
             }
         gm_params = make_model_configs(**cfg)
         num_states_list, num_obs_list = gm_params['ns_list'], gm_params['no_list']
@@ -123,7 +123,7 @@ class TestMessagePassing(unittest.TestCase):
         and observation modalities
         """
         cfg = {'source_seed': 3,
-                'num_models': 4
+                'num_models': 3
             }
         gm_params = make_model_configs(**cfg)
 
@@ -152,7 +152,7 @@ class TestMessagePassing(unittest.TestCase):
     def test_marginal_message_passing(self):
 
         cfg = {'source_seed': 5,
-                'num_models': 4
+                'num_models': 3
             }
         gm_params = make_model_configs(**cfg)
 

--- a/test/test_tmaze_recoverability.py
+++ b/test/test_tmaze_recoverability.py
@@ -9,12 +9,12 @@ def _small_cfg(parameterization: str) -> RecoverabilityConfig:
     return RecoverabilityConfig(
         parameterization=parameterization,
         seed=3,
-        num_agents=5,
-        num_blocks=12,
-        num_trials=5,
-        svi_steps=40,
+        num_agents=4,
+        num_blocks=8,
+        num_trials=4,
+        svi_steps=24,
         num_particles=1,
-        num_samples=16,
+        num_samples=8,
     )
 
 
@@ -23,8 +23,8 @@ def test_tmaze_recoverability_three_param_smoke():
 
     assert results["num_params"] == 3
     assert len(results["corr_latent"]) == 3
-    assert len(results["true_reward_probability"]) == 5
-    assert len(results["inferred_reward_probability"]) == 5
+    assert len(results["true_reward_probability"]) == 4
+    assert len(results["inferred_reward_probability"]) == 4
     assert 0.0 <= results["bimodality_score_reward_probability"] <= 1.0
     assert math.isfinite(results["corr_reward_probability"])
 
@@ -34,7 +34,7 @@ def test_tmaze_recoverability_reward_only_smoke():
 
     assert results["num_params"] == 1
     assert len(results["corr_latent"]) == 1
-    assert len(results["true_reward_probability"]) == 5
-    assert len(results["inferred_reward_probability"]) == 5
+    assert len(results["true_reward_probability"]) == 4
+    assert len(results["inferred_reward_probability"]) == 4
     assert 0.0 <= results["bimodality_score_reward_probability"] <= 1.0
     assert math.isfinite(results["corr_reward_probability"])


### PR DESCRIPTION
## Summary
- reduces runtime of several heavy tests while preserving coverage intent
- introduces a `nightly` pytest marker and moves the long HMM stability test to nightly
- marks the long-horizon numeric stability HMM associative scan for filteirng/smoothing nightly, and reduces its state dimension to K=48 rather than K=100
- updates regular CI to run `-m "not nightly"`
- adds scheduled nightly workflow that runs nightly-marked tests

## Timing
- before: `pytest test -n 2` -> `242 passed in 234.74s` (`real 236.39s`)
- after (pre-nightly split): `pytest test -n 2` -> `242 passed in 185.67s` (`real 186.88s`)
- after nightly split (regular CI path): `pytest test -n 2 -m "not nightly"` -> `241 passed in 188.30s` (`real 189.32s`)

## Validation
- `pytest test/test_hmm_associative_scan.py -n 2 -m "not nightly"`
- `pytest test/test_hmm_associative_scan.py -n 2 -m nightly`
- `pytest test -n 2 -m "not nightly"`
