### PR TITLE
Add notebook test manifests for release gating

### DIFF
--- a/test/notebooks/README.md
+++ b/test/notebooks/README.md
@@ -25,6 +25,7 @@ The nightly tier is currently locked to:
 - `examples/advanced/pymdp_with_neural_encoder.ipynb`
 - `examples/learning/learning_gridworld.ipynb`
 - `examples/model_fitting/fitting_with_pybefit.ipynb`
+- `examples/sparse/sparse_benchmark.ipynb`
 
 All other non-legacy notebooks in `examples/` belong to the CI tier.
 

--- a/test/notebooks/ci_notebooks.txt
+++ b/test/notebooks/ci_notebooks.txt
@@ -14,4 +14,3 @@ examples/experimental/sophisticated_inference/si_tmaze_SIvalidation.ipynb
 examples/inductive_inference/inductive_inference_example.ipynb
 examples/inductive_inference/inductive_inference_gridworld.ipynb
 examples/inference_and_learning/inference_methods_comparison.ipynb
-examples/sparse/sparse_benchmark.ipynb

--- a/test/notebooks/nightly_notebooks.txt
+++ b/test/notebooks/nightly_notebooks.txt
@@ -1,3 +1,4 @@
 examples/advanced/pymdp_with_neural_encoder.ipynb
 examples/learning/learning_gridworld.ipynb
 examples/model_fitting/fitting_with_pybefit.ipynb
+examples/sparse/sparse_benchmark.ipynb


### PR DESCRIPTION
## Context
This workstream adds the release-tracker notebook scaffolding for `v1.0.0_alpha` without changing workflow behavior yet. It gives downstream notebook work a stable, explicit source of truth for the PR-CI and nightly notebook tiers.

## Issue links
Part of #195
Part of #239

## Scope
- add `test/notebooks/ci_notebooks.txt`
- add `test/notebooks/nightly_notebooks.txt`
- update `test/notebooks/README.md` to describe the manifest-driven split and current `examples/legacy/` exclusion

## Validation
- verified the CI and nightly manifests are disjoint
- verified every manifest entry exists in the repository
- verified the union of both manifests matches the full current non-legacy `examples/**/*.ipynb` set

## Non-goals
- no workflow changes in `.github/workflows/*`
- no notebook content fixes
- no pre-commit or sanitation policy changes
