### PR TITLE
docs: clarify pygraphviz installation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ If you prefer `pip`, use:
 pip install inferactively-pymdp
 ```
 
+If `uv sync --group test` or `uv sync --extra nb` fails while building `pygraphviz`, install Graphviz first and then retry. On macOS, install `graphviz` with Homebrew. On Ubuntu/Debian, install `graphviz libgraphviz-dev pkg-config build-essential` plus matching Python development headers if `Python.h` is missing. The full troubleshooting notes live in [`docs-mkdocs/getting-started/installation.md`](docs-mkdocs/getting-started/installation.md).
+
 Once in Python, you can then directly import `pymdp`, its sub-packages, and functions.
 
 ```python

--- a/docs-mkdocs/getting-started/installation.md
+++ b/docs-mkdocs/getting-started/installation.md
@@ -28,6 +28,8 @@ uv sync --group test
 - `--extra gpu`: installs CUDA-enabled JAX packages.
 - `--extra docs`: documentation toolchain (`mkdocs`, `mkdocs-material`, `mkdocstrings`, `mkdocs-jupyter`, `mkdocs-redirects`).
 
+`pygraphviz` is only needed for Graphviz-backed notebook visualizations such as the MCTS graph-world demo, but it is included in the current `test` and `nb` dependency sets. On many machines `uv sync --group test` works without any extra steps; if it fails while building `pygraphviz`, use the troubleshooting notes below and then rerun the sync command.
+
 Common `uv` sync patterns:
 
 ```bash
@@ -46,6 +48,78 @@ uv sync --group test --extra docs
 # GPU workflow
 uv sync --group test --extra gpu
 ```
+
+## `pygraphviz` troubleshooting
+
+If installation fails while building `pygraphviz`, the missing dependency is usually one of:
+
+- Graphviz itself, including the C headers (`graphviz/cgraph.h`)
+- Python development headers for the exact interpreter version in your virtual environment (`Python.h`)
+
+### macOS (Homebrew)
+
+Install Graphviz with Homebrew before syncing dependencies:
+
+```bash
+brew install graphviz
+```
+
+If `pygraphviz` still fails to build, install it explicitly with Homebrew's include and library paths:
+
+```bash
+uv pip install \
+  --config-settings=--global-option=build_ext \
+  --config-settings=--global-option="-I$(brew --prefix graphviz)/include" \
+  --config-settings=--global-option="-L$(brew --prefix graphviz)/lib" \
+  pygraphviz==1.14
+```
+
+Then rerun:
+
+```bash
+uv sync --group test
+```
+
+or, if you only need the notebook/media extras:
+
+```bash
+uv sync --extra nb
+```
+
+### Ubuntu / Debian
+
+Install the Graphviz runtime, Graphviz development headers, `pkg-config`, and the compiler toolchain before syncing dependencies:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y graphviz libgraphviz-dev pkg-config build-essential
+```
+
+Install Python development headers that match the interpreter in your environment:
+
+```bash
+sudo apt-get install -y python3-dev
+```
+
+If you are using a version-specific interpreter that is newer than the system default, install the matching package instead, for example:
+
+```bash
+sudo apt-get install -y python3.12-dev
+```
+
+Then rerun:
+
+```bash
+uv sync --group test
+```
+
+or install the dependency directly inside the active environment:
+
+```bash
+uv pip install pygraphviz==1.14
+```
+
+If the build output mentions `graphviz/cgraph.h`, install or verify the Graphviz development packages above. If it mentions `Python.h`, install or verify the matching Python development headers.
 
 ## Verify docs build
 ```bash


### PR DESCRIPTION
## Summary
- add explicit `pygraphviz` troubleshooting guidance for macOS and Ubuntu/Debian
- document the system packages needed for Ubuntu/Debian builds and the Homebrew fallback path on macOS
- clarify in the install docs and README when `pygraphviz` is pulled in by the current dependency sets

## Validation
- validated `pygraphviz` installation locally on macOS with Homebrew Graphviz installed
- validated the Ubuntu/Debian package recipe in a clean Ubuntu 22.04 environment 
- confirmed `uv sync --group test` completed successfully in Ubuntu environment once the required system packages were present

Fixes #268