### PR TITLE
docs: expand 1.0.0 release notes

### DIFF
--- a/docs-mkdocs/development/release-notes.md
+++ b/docs-mkdocs/development/release-notes.md
@@ -138,14 +138,13 @@ If you are upgrading from the legacy NumPy backend, start with the
 ### Packaging, Testing, And Contributor Workflow
 
 - The packaging surface now centers on `pyproject.toml` and setuptools-backed
-  builds, with explicit extras and groups for `gpu`, `docs`, `nb`, and
-  `modelfit` workflows.
+  builds, with explicit optional-dependency extras for `gpu`, `docs`, `nb`,
+  and `modelfit` workflows.
 - Notebook execution is now tiered and enforced through manifests: PR CI runs
   the `test/notebooks/ci_notebooks.txt` tier, while nightly coverage runs the
   `test/notebooks/nightly_notebooks.txt` tier.
 - Contributor workflow also improved through notebook sanitation hooks, strict
-  docs builds, unit-test coverage reporting, `pytest-xdist` support, and an
-  explicit release checklist for the final `1.0.0` closeout process.
+  docs builds, unit-test coverage reporting, and `pytest-xdist` support.
 
 ### Traceability Appendix
 


### PR DESCRIPTION
## Summary
- replace the placeholder 1.0.0 release note with a fuller release summary grounded in the `v0.0.7.1..v1.0.0_alpha` branch history
- document the main migration and feature themes for 1.0.0, including the JAX-first transition, new `rollout()` / `infer_and_plan()` APIs, autodifferentiable agent workflows, sparse `A_dependencies` / `B_dependencies`, MCTS-based sophisticated inference, and model-fitting support via `pybefit` + NumPyro
- add a short traceability appendix tying each major section back to representative commits and file paths

Addresses #374.