### PR TITLE
docs(notebook): fix center_left preference comment in model construction tutorial

### DIFF
--- a/examples/api/model_construction_tutorial.ipynb
+++ b/examples/api/model_construction_tutorial.ipynb
@@ -109,7 +109,7 @@
     "model.B[\"position\"][\"center_left\", \"center_right\", \"move_left\"] = 1.0  \n",
     "model.B[\"position\"][\"center_right\", \"right\", \"move_left\"] = 1.0    \n",
     "\n",
-    "# set preferences (C) tensor - prefer to be at \"center_right\"\n",
+    "# set preferences (C) tensor - prefer to be at \"center_left\"\n",
     "model.C[\"position_obs\"][\"center_left\"] = 1.0"
    ]
   },


### PR DESCRIPTION
Closes #388.

The comment on the preferences (C) tensor cell in `examples/api/model_construction_tutorial.ipynb` says

```python
# set preferences (C) tensor - prefer to be at "center_right"
model.C["position_obs"]["center_left"] = 1.0
```

but the line immediately below sets the preference on `"center_left"`. Flip the comment so it matches the assigned position.

## Testing

- Notebook-only change.
- Round-tripped through `json.loads` / `json.dumps(..., indent=1, ensure_ascii=False)` to keep the file's existing formatting and nbformat metadata untouched; `git diff --stat` reports `1 file changed, 1 insertion(+), 1 deletion(-)`.