### PR TITLE
deps: pin jax/jaxlib <0.10 pending numpyro fix (#389)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,11 @@ classifiers=[
 requires-python = ">=3.10"
 dependencies = [
     'numpy>=1.19.5',
-    'jax>=0.3.4',
-    'jaxlib>=0.3.4',
+    # jax/jaxlib upper-bounded until numpyro ships the fix from
+    # https://github.com/pyro-ppl/numpyro/pull/2173 (jax 0.10.0 removed
+    # xla_pmap_p, which breaks numpyro -> pybefit imports). See issue #389.
+    'jax>=0.3.4,<0.10',
+    'jaxlib>=0.3.4,<0.10',
     'equinox>=0.9',
     'multimethod>=1.11',
     'matplotlib>=3.1.3',
@@ -57,7 +60,7 @@ test = [
 
 [project.optional-dependencies]
 gpu = [
-    'jax[cuda12]>=0.3.4',
+    'jax[cuda12]>=0.3.4,<0.10',
 ]
 docs = [
     "mkdocs>=1.6.1,<2",

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,12 @@ project_urls =
 packages = find:
 install_requires =
     numpy>=1.19.5
-    jax>=0.3.4
-    jaxlib>=0.3.4
+    # jax/jaxlib upper-bounded until numpyro ships the fix from
+    # https://github.com/pyro-ppl/numpyro/pull/2173 (jax 0.10.0 removed
+    # xla_pmap_p, which breaks numpyro -> pybefit imports). See issue #389.
+    # Keep in sync with pyproject.toml.
+    jax>=0.3.4,<0.10
+    jaxlib>=0.3.4,<0.10
     equinox>=0.9
     multimethod>=1.11
     matplotlib>=3.1.3
@@ -34,7 +38,7 @@ include_package_data = True
 
 [options.extras_require]
 gpu =
-    jax[cuda12]>=0.3.4
+    jax[cuda12]>=0.3.4,<0.10
 
 [options.package_data]
 pymdp = envs/assets/*


### PR DESCRIPTION
## Summary
- Nightly CI has been failing since jax 0.10.0 landed — it removed `xla_pmap_p` from `jax.extend.core.primitives`, which is imported unconditionally by `numpyro/ops/provenance.py`. That breaks `import numpyro`, which in turn breaks `pybefit` and the two model-fitting test modules (`test_pybefit_model_fitting.py`, `test_tmaze_recoverability.py`).
- Upstream fix is [pyro-ppl/numpyro#2173](https://github.com/pyro-ppl/numpyro/pull/2173) (approved, not yet merged/released). Tracking bug: [pyro-ppl/numpyro#2174](https://github.com/pyro-ppl/numpyro/issues/2174).
- This PR pins `jax`/`jaxlib` to `<0.10` as a short-term workaround and adds a comment in `pyproject.toml` pointing at the upstream PR so we remember to revert.
- Closes #389 once merged; revert this pin as soon as a patched numpyro release is on PyPI.

## Test plan
- [x] `uv lock --dry-run` resolves jax 0.9.2, numpyro 0.20.1, pybefit 0.1.23 cleanly
- [x] Nightly Tests CI run on this branch (via `manual-branch-nightly.yaml`) passes
- [x] Standard `Test` CI on this PR passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)