### PR TITLE
fix: replace mutable default `shape=[2,2]` with `None` guard in grid_worlds.py

### DIFF
--- a/pymdp/legacy/envs/grid_worlds.py
+++ b/pymdp/legacy/envs/grid_worlds.py
@@ -26,7 +26,7 @@ class GridWorldEnv(Env):
 
     CONTROL_NAMES = ["UP", "RIGHT", "DOWN", "LEFT", "STAY"]
 
-    def __init__(self, shape=[2, 2], init_state=None):
+    def __init__(self, shape=None, init_state=None):
         """
         Initialization function for 2-D grid world
 
@@ -38,7 +38,8 @@ class GridWorldEnv(Env):
             Initial state of the environment, i.e. the location of the agent in grid world. If not ``None``, must be a discrete index  in the range ``(0, (shape[0] * shape[1])-1)``. It is thus a "linear index" of the initial location of the agent in grid world.
             If ``None``, then an initial location will be randomly sampled from the grid.
         """
-        
+        if shape is None:
+            shape = [2, 2]
         self.shape = shape
         self.n_states = np.prod(shape)
         self.n_observations = self.n_states
@@ -201,7 +202,9 @@ class DGridWorldEnv(object):
 
     CONTROL_NAMES = ["LEFT", "STAY", "RIGHT"]
 
-    def __init__(self, shape=[2, 2], init_state=None):
+    def __init__(self, shape=None, init_state=None):
+        if shape is None:
+            shape = [2, 2]
         self.shape = shape
         self.n_states = np.prod(shape)
         self.n_observations = self.n_states


### PR DESCRIPTION
## Summary

Fixes #392

Both `GridWorldEnv` and `DGridWorldEnv` in `pymdp/legacy/envs/grid_worlds.py` used a mutable list `[2, 2]` as a default argument:

```python
def __init__(self, shape=[2, 2], init_state=None):
```

Using a mutable default is a Python anti-pattern (PEP B006). Python evaluates default argument values **once** at function definition time, so any in-place mutation of the shared list object would silently affect all future calls that rely on the default. Although the current code does not mutate `shape` in-place today, this is a latent bug and flagged by static analysis.

## Fix

Replace the mutable default with `None` and assign the list inside the function body:

```python
def __init__(self, shape=None, init_state=None):
    if shape is None:
        shape = [2, 2]
```

Applied to both `GridWorldEnv.__init__` and `DGridWorldEnv.__init__`.

Signed-off-by: lingxiu58 <86288566+lingxiu58@users.noreply.github.com>