### PR TITLE
fix(maths): clip y in stable_cross_entropy to prevent NaN/-inf

### DIFF
--- a/pymdp/maths.py
+++ b/pymdp/maths.py
@@ -59,7 +59,7 @@ def stable_cross_entropy(x: ArrayLike, y: ArrayLike) -> ArrayLike:
     ArrayLike
         Cross-entropy value.
     """
-    return - xlogy(x, y).sum()
+    return - xlogy(x, jnp.clip(y, MINVAL)).sum()
 
 def log_stable(x: ArrayLike) -> ArrayLike:
     """Compute stable logarithm with minimum clipping.


### PR DESCRIPTION
## Summary

Fixes #394

`stable_cross_entropy(x, y)` passes `y` directly to `xlogy(x, y)`, which computes `x * log(y)`. When `y` contains zero-probability values this produces `-inf` or `NaN`, silently corrupting VFE calculations.

Every other numerically sensitive function in `maths.py` already clips to `MINVAL` before logging (`stable_xlogx`, `log_stable`, `dirichlet_expected_value`, …). This one-line fix brings `stable_cross_entropy` in line with that convention.

## Change

```python
# Before
return - xlogy(x, y).sum()

# After
return - xlogy(x, jnp.clip(y, MINVAL)).sum()
```

## Testing

The fix is a one-line change identical in structure to the existing `stable_xlogx` implementation, which already has test coverage. A quick sanity check:

```python
x = jnp.array([0.5, 0.5])
y = jnp.array([0.0, 1.0])
print(stable_cross_entropy(x, y))  # Before: -inf | After: finite value
```

---
Signed-off-by: lingxiu58 <86288566+lingxiu58@users.noreply.github.com>