### PR TITLE
ci: switch release-please to a PAT and document conventional commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,11 +3,6 @@ name: release-please
 on:
   push:
     branches: [main]
-  # Manual escape hatch: release-please's own PR merges produce a
-  # github-actions[bot]-authored commit, which suppresses the push
-  # trigger. Until we switch to a PAT/App token, workflow_dispatch
-  # lets us re-fire the workflow by hand from the Actions tab.
-  workflow_dispatch:
 
 # Default to least-privilege; jobs that need more elevate per-job.
 permissions:
@@ -27,7 +22,12 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT instead of GITHUB_TOKEN so commits and PRs created
+          # by release-please are authored by a real user account, which
+          # lets the merge of release-please's own PR trigger this
+          # workflow's push event (GITHUB_TOKEN-authored events are
+          # suppressed by GitHub's recursion guard).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,3 +208,34 @@ Some automated tests will also run in the background to make sure that your
 code can be imported correctly and other sanity checks. Once that is all done, 
 one of us will either accept your Pull Request, or leave a message requesting some
 changes (you will receive an email either way).
+
+
+## Pull request titles & releases
+
+Releases are automated by [release-please](https://github.com/googleapis/release-please).
+Every PR is squash-merged into `main`, so the **PR title becomes the commit message
+on `main`** — and release-please reads those messages to compute the next version
+number and to write `CHANGELOG.md`. PR titles must therefore follow the
+[Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>(<optional scope>): <short description>
+```
+
+Common types and what they trigger in the changelog and version:
+
+| Type | Effect |
+|---|---|
+| `feat:` | minor version bump, listed under "Features" (e.g. `feat(planning): add iterative-deepening MCTS`) |
+| `fix:` | patch version bump, listed under "Bug Fixes" (e.g. `fix(maths): clip y in stable_cross_entropy`) |
+| `deps:` | patch bump, listed under "Dependencies" (e.g. `deps: bump jax to 0.10`) |
+| `perf:` | patch bump, listed under "Performance" |
+| `docs:` / `refactor:` | listed in changelog, no version bump |
+| `chore:` / `ci:` / `test:` / `build:` / `style:` | hidden from changelog, no version bump |
+
+**Breaking changes:** append `!` after the type/scope (e.g. `feat(agent)!: change Agent.step return type`)
+**or** include a `BREAKING CHANGE: <description>` footer in the PR description body.
+Either form triggers a major version bump and a "⚠ BREAKING CHANGES" section in the changelog.
+
+**Linking issues:** include `Fixes #N` or `Closes #N` in the PR description (not just the title)
+to auto-link the issue from the corresponding changelog entry.


### PR DESCRIPTION
## Summary
- Switch `release-please-action` from `GITHUB_TOKEN` to `RELEASE_PLEASE_TOKEN` (a fine-grained PAT scoped to `infer-actively/pymdp` with `contents`, `pull-requests`, and `issues` permissions). With a PAT, release-please's commits and PR are authored by a real user account, so the merge of release-please's own PR triggers this workflow's `push` event normally. No more manual nudge required after merging the release PR (the issue we hit cutting 1.0.1).
- Drop the `workflow_dispatch:` escape hatch added in [bb0aa7e](https://github.com/infer-actively/pymdp/commit/bb0aa7e), since the PAT eliminates the need for it.
- Add a CONTRIBUTING section explaining that with squash-merge the **PR title** is what release-please reads, and that PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) — including a quick reference table for `feat:` / `fix:` / `deps:` / `perf:` / `docs:` / `refactor:` / `chore:` etc., breaking-change syntax, and how to link issues from the changelog.

## Why
1.0.1 didn't auto-publish on merge of #397 because `GITHUB_TOKEN`-authored commits are suppressed from triggering downstream workflow runs (GitHub's recursion guard). The release-please docs explicitly recommend a PAT or GitHub App token for exactly this reason. PAT route picked over a GitHub App because for a single-repo project it's substantially less setup for similar effective security.

## Test plan
- [ ] Merge this PR via squash-merge.
- [ ] Confirm the next `release-please` workflow run uses `RELEASE_PLEASE_TOKEN` (visible in the action step's resolved inputs).
- [ ] Wait for the next conventional-commit PR to land on `main`; verify release-please opens a Release PR.
- [ ] Merge that Release PR; verify the workflow fires automatically (without needing an empty commit / workflow_dispatch).
- [ ] Verify build → publish chain runs end-to-end and the new version reaches PyPI.


🤖 Generated with [Claude Code](https://claude.com/claude-code)