### PR TITLE
docs(contributing): fix release-trigger table and document cadence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,8 +230,26 @@ Common types and what they trigger in the changelog and version:
 | `fix:` | patch version bump, listed under "Bug Fixes" (e.g. `fix(maths): clip y in stable_cross_entropy`) |
 | `deps:` | patch bump, listed under "Dependencies" (e.g. `deps: bump jax to 0.10`) |
 | `perf:` | patch bump, listed under "Performance" |
-| `docs:` / `refactor:` | listed in changelog, no version bump |
+| `revert:` | patch bump, listed under "Reverts" |
+| `docs:` | patch bump, listed under "Documentation" |
+| `refactor:` | patch bump, listed under "Refactors" |
 | `chore:` / `ci:` / `test:` / `build:` / `style:` | hidden from changelog, no version bump |
+
+### Release cadence
+
+A release isn't cut every time a conventional-commit PR is merged. release-please
+keeps a single rolling **Release PR** open, representing the next pending release.
+Each merged PR with a visible type from the table above updates that Release PR —
+appending to its CHANGELOG and re-bumping the proposed version as needed (e.g. a
+`feat:` arriving after several `fix:` pushes the Release PR from a patch bump to
+a minor bump). Hidden-type PRs (`chore:`, `ci:`, `test:`, `build:`, `style:`)
+don't affect the Release PR. A release happens **only when a maintainer merges
+the Release PR**, so content accumulates until then and a single release
+typically covers multiple PRs.
+
+Maintainers should batch the Release PR sensibly — e.g. let pure-`docs:` Release
+PRs sit until code changes join them, but cut a release promptly for important
+bug fixes.
 
 **Breaking changes:** append `!` after the type/scope (e.g. `feat(agent)!: change Agent.step return type`)
 **or** include a `BREAKING CHANGE: <description>` footer in the PR description body.


### PR DESCRIPTION
- Fix wrong row in the conventional-commits table: \`docs:\` / \`refactor:\` actually trigger patch bumps (the previous "no version bump" claim was wrong, as PR #402 demonstrated).
- Add missing \`revert:\` row.
- Add a "Release cadence" subsection explaining release-please's rolling Release PR model.