### PR TITLE
fix: squeeze only axis 0 in dot_likelihood to prevent shape mismatch

### DIFF
--- a/pymdp/legacy/maths.py
+++ b/pymdp/legacy/maths.py
@@ -242,7 +242,7 @@ def dot_likelihood(A,obs):
     s[0] = obs.shape[0]
     X = A * obs.reshape(tuple(s))
     X = np.sum(X, axis=0, keepdims=True)
-    LL = np.squeeze(X)
+    LL = np.squeeze(X, axis=0)
 
     # check to see if `LL` is a scalar
     if np.prod(LL.shape) <= 1.0:


### PR DESCRIPTION
## Problem

`np.squeeze(X)` in `dot_likelihood()` (`pymdp/legacy/maths.py:245`) removes **all** size-1 dimensions. When `A` has shape `(1, N, 1)` (e.g., single-modality with trailing dimension), this collapses both axes, returning `(N,)` instead of the expected `(N, 1)`. This causes shape mismatches in downstream `calc_free_energy()` calls within `fpi.py`.

## Fix

```python
# Before
LL = np.squeeze(X)

# After
LL = np.squeeze(X, axis=0)
```

Restricts squeeze to axis 0 only, preserving the trailing dimension and maintaining shape consistency.

## Reproduction

```python
import numpy as np
from pymdp.legacy.maths import dot_likelihood

A = np.expand_dims(np.eye(25), axis=-1)  # shape (25, 25, 1)
obs = np.eye(1, 25).flatten()

LL = dot_likelihood(A, obs)
# Before: LL.shape == (25,)   ← wrong
# After:  LL.shape == (25, 1) ← correct
```

Fixes #171