### PR TITLE
fix(maths): eliminate cancellation error in exact parameter info-gain weight

### DIFF
--- a/pymdp/maths.py
+++ b/pymdp/maths.py
@@ -784,6 +784,11 @@ def _exact_wnorm(A: ArrayLike) -> ArrayLike:
     """
     Implements (-1) * eq. (D.15) in Da Costa et al. ‘Active inference on discrete state-spaces: A synthesis’, Journal of Mathematical Psychology, 2020.
 
+    Note: the direct expansion of eq. (D.15) sums `1/A - 1/sumA` with `digamma(A) - digamma(sumA)`; both terms
+    diverge as A shrinks and are supposed to cancel, which is numerically unstable in finite precision.
+    Using the digamma recurrence `digamma(x+1) = digamma(x) + 1/x` lets those terms cancel algebraically
+    instead, avoiding the cancellation entirely.
+
     Note: Like the legacy SPM implementation this function clips A for numerical stability. However note that if some values of Aare set to zero e.g. by Bayesian model reduction, these are non-zeroed in this calculation, and thus contribute a large amount to the information gain unless these are zeroed when multiplying by beliefs about states and expected observations. In principle, this should be the case.
 
     Parameters
@@ -802,8 +807,7 @@ def _exact_wnorm(A: ArrayLike) -> ArrayLike:
 
     wA = (
         jnp.log(safe_sumA) - jnp.log(safe_A)
-        + 1. / safe_A - 1. / safe_sumA
-        + digamma(safe_A) - digamma(safe_sumA)
+        + digamma(safe_A + 1.) - digamma(safe_sumA + 1.)
     )
 
     return -wA # TODO: minus sign here gives negative info gain for backward compatibility with spm implementation. Later will need to remove minus sign here to get positive info gain and adjust function documentation accordingly.

--- a/test/test_param_info_gain_jax.py
+++ b/test/test_param_info_gain_jax.py
@@ -49,7 +49,9 @@ def test_exact_wnorm_mathematical_correctness():
     )
     expected = -expected  # minus sign in the implementation
 
-    np.testing.assert_allclose(result, expected, rtol=1e-4, atol=1e-4)
+    # Measured max relative diff between the two forms on this input is ~4.8e-6 in
+    # float32 (see discussion on PR #415); rtol/atol below leave a ~3-11x margin above that.
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-6)
 
     # Verify output shape matches input
     assert result.shape == A.shape
@@ -61,9 +63,9 @@ def test_exact_wnorm_symmetric_tiny_concentrations_match_log_k(K, a):
     """For a symmetric Dirichlet (all K entries equal to `a`), the exact value of eq. (D.15)
     as `a -> 0` is `-log(K)`: both `digamma(a+1)` and `digamma(K*a+1)` tend to `digamma(1)`
     and cancel, leaving only `log(K)`. This is an independent closed-form reference (no
-    digamma evaluation needed at the limit), so it directly catches the cancellation bug:
-    the pre-fix direct-expansion formula drifts further from `-log(K)` as `a` shrinks
-    instead of converging to it.
+    digamma evaluation needed at the limit), so it directly catches the cancellation error
+    described in #340: the pre-fix direct-expansion formula drifts further from `-log(K)`
+    as `a` shrinks instead of converging to it.
     """
     A = jnp.full((K, 1), a)
     result = _exact_wnorm(A)

--- a/test/test_param_info_gain_jax.py
+++ b/test/test_param_info_gain_jax.py
@@ -32,24 +32,43 @@ def test_exact_wnorm_mathematical_correctness():
     # Simple 2x2 case with known values
     A = jnp.array([[1.0, 2.0],
                    [3.0, 4.0]])
-    
+
     result = _exact_wnorm(A)
-    
-    # Manually compute expected result using the formula
-    # wA = log(A.sum(0)) - log(A) + 1/A - 1/A.sum(0) + digamma(A) - digamma(A.sum(0))
+
+    # Reference: direct expansion of eq. (D.15), stable at this magnitude since A is
+    # far from MINVAL. Mathematically equivalent to the implementation (see the digamma
+    # recurrence note in _exact_wnorm's docstring), so both should agree up to float32
+    # rounding -- the two forms don't round identically since they go through different
+    # sequences of operations.
     A_sum = A.sum(axis=0)  # [4.0, 6.0]
-    
+
     expected = (
         jnp.log(A_sum) - jnp.log(A) +
         1.0 / A - 1.0 / A_sum +
         jnp.array(digamma(A)) - jnp.array(digamma(A_sum))
     )
     expected = -expected  # minus sign in the implementation
-    
-    np.testing.assert_allclose(result, expected, rtol=1e-6, atol=1e-8)
-    
+
+    np.testing.assert_allclose(result, expected, rtol=1e-4, atol=1e-4)
+
     # Verify output shape matches input
-    assert result.shape == A.shape 
+    assert result.shape == A.shape
+
+
+@pytest.mark.parametrize("K", [2, 5, 10, 50])
+@pytest.mark.parametrize("a", [1e-8, 1e-12, 1e-15])
+def test_exact_wnorm_symmetric_tiny_concentrations_match_log_k(K, a):
+    """For a symmetric Dirichlet (all K entries equal to `a`), the exact value of eq. (D.15)
+    as `a -> 0` is `-log(K)`: both `digamma(a+1)` and `digamma(K*a+1)` tend to `digamma(1)`
+    and cancel, leaving only `log(K)`. This is an independent closed-form reference (no
+    digamma evaluation needed at the limit), so it directly catches the cancellation bug:
+    the pre-fix direct-expansion formula drifts further from `-log(K)` as `a` shrinks
+    instead of converging to it.
+    """
+    A = jnp.full((K, 1), a)
+    result = _exact_wnorm(A)
+    expected = -jnp.log(float(K))
+    np.testing.assert_allclose(result, expected, rtol=1e-4, atol=1e-4)
 
 
 # -----------------------------------------------------------------------------

--- a/test/test_param_info_gain_jax.py
+++ b/test/test_param_info_gain_jax.py
@@ -70,7 +70,10 @@ def test_exact_wnorm_symmetric_tiny_concentrations_match_log_k(K, a):
     A = jnp.full((K, 1), a)
     result = _exact_wnorm(A)
     expected = -jnp.log(float(K))
-    np.testing.assert_allclose(result, expected, rtol=1e-4, atol=1e-4)
+
+    # Measured max abs diff across all (K, a) parametrizations is ~1.9e-6 in float32;
+    # rtol/atol below leave at least a ~5.5x margin above that in the worst case (K=2, a=1e-15).
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-6)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #340

`_exact_wnorm` computes eq. (D.15) from Da Costa et al. 2020 as:

    w = log(sumA) - log(A) + 1/A - 1/sumA + digamma(A) - digamma(sumA)

As A shrinks toward MINVAL, `1/A` and `digamma(A)` both diverge with opposite
sign and are supposed to cancel down to an O(1) value. In float32 that
cancellation is inexact, so the term comes out wrong by several orders of
magnitude for small Dirichlet counts. The error is also erratic rather than
a smooth degradation, matching the oscillating behavior described in the
issue.

Using the digamma recurrence `digamma(x+1) = digamma(x) + 1/x`, substitute
for `1/A` and `1/sumA`:

    w = log(sumA) - log(A)
        + [digamma(A+1) - digamma(A)]
        - [digamma(sumA+1) - digamma(sumA)]
        + digamma(A) - digamma(sumA)

The `digamma(A)` and `digamma(sumA)` terms cancel exactly, leaving:

    w = log(sumA) - log(A) + digamma(A+1) - digamma(sumA+1)

This reformulation is algebraically identical to the original expression. It
changes only the numerical evaluation order. The divergent terms are removed
before any floating-point evaluation happens, so the implementation no
longer depends on cancellation between divergent quantities.

## Testing

- Randomized stress testing against float64 and mpmath, plus a deterministic
  logarithmic sweep from 1e-20 to 1e3: the original formula's error grows to
  roughly six orders of magnitude near the clipping threshold, while the
  rewritten version stays within float32's ordinary rounding error across the
  same range.
- Verified under jit, vmap, and autodiff (the composition control.py and
  agent.py use for policy inference), including the zero-entry case from
  Bayesian model reduction.
- The existing correctness test previously compared the implementation to a
  hand-copied version of the same pre-fix formula, so it would pass
  regardless of correctness. Added a test against `-log(K)`, the closed-form
  limit eq. (D.15) converges to for a symmetric Dirichlet as concentration
  goes to zero. This reference is independent of either formula.
- Full suite passes (294 passed, 1 skipped, one pre-existing unrelated
  failure from a missing `numpyro` dependency). `ruff check` is clean.