### PR TITLE
fix(agent): back Policies with a hashable tuple

### DIFF
--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -211,14 +211,14 @@ class Agent(Module):
         if (
             policies is None and B_action_dependencies is not None
         ):  # note, this only works when B_action_dependencies is not the trivial case of [[0], [1], ...., [num_factors-1]]
-            policies_multi = control.construct_policies(
+            policies_multi_tup = control._construct_policies_tuple(
                 self.num_controls_multi,
                 self.num_controls_multi,
                 policy_len,
                 control_fac_idx,
             )
             B, pB, self.action_maps = self._flatten_B_action_dims(B, pB, self.B_action_dependencies)
-            policies = self._construct_flattend_policies(policies_multi, self.action_maps)
+            policies = self._construct_flattend_policies_tuple(policies_multi_tup, self.action_maps)
             self.sampling_mode = "full"
         
         # extract shapes from A and B
@@ -307,18 +307,23 @@ class Agent(Module):
 
         # construct policies
         if policies is None:
-            policies_array = control.construct_policies(
+            policies_tup = control._construct_policies_tuple(
                 self.num_states,
                 self.num_controls,
                 self.policy_len,
                 self.control_fac_idx,
             )
-            self.policies = control.Policies(policies_array)
+            self.policies = control.Policies(policies_tup)
         else:
-            if not isinstance(policies, control.Policies):
-                self.policies = control.Policies(jnp.array(policies))
-            else:
+            if isinstance(policies, control.Policies):
                 self.policies = policies
+            elif isinstance(policies, tuple):
+                # already a concrete nested tuple (e.g. from `_construct_flattend_policies_tuple`);
+                # pass it straight through so `Policies.__init__` doesn't need to round-trip it
+                # through `jnp.array` first, which would defeat the point under an active jit trace
+                self.policies = control.Policies(policies)
+            else:
+                self.policies = control.Policies(jnp.array(policies))
 
         if C is None:
             C = [jnp.ones((self.batch_size, self.num_obs[m])) / self.num_obs[m] for m in range(self.num_modalities)]
@@ -1135,6 +1140,47 @@ class Agent(Module):
             )
         policies_flat = jnp.stack(policies_flat, axis=-1)
         return policies_flat
+
+    def _construct_flattend_policies_tuple(
+        self, policies_tup: tuple, action_maps: list[dict[str, Any]]
+    ) -> tuple:
+        """
+        Pure-Python equivalent of `_construct_flattend_policies`, operating on and
+        returning nested tuples instead of `jnp.ndarray`. Mirrors
+        `utils.get_combination_index`'s mixed-radix encoding exactly, but never invokes
+        a JAX primitive, so it's safe to call while `Agent.__init__` is itself being
+        traced under `jax.jit` (see `control._construct_policies_tuple`'s docstring for
+        why that matters).
+        """
+        num_policies = len(policies_tup)
+        horizon = len(policies_tup[0])
+
+        columns = []
+        for action_map in action_maps:
+            multi_dependency = action_map["multi_dependency"]
+            if multi_dependency == []:
+                columns.append(tuple(tuple(0 for _ in range(horizon)) for _ in range(num_policies)))
+                continue
+
+            dims = action_map["multi_dims"]
+            column = []
+            for policy in policies_tup:
+                row = []
+                for t in range(horizon):
+                    xs = [policy[t][d] for d in multi_dependency]
+                    index = 0
+                    product = 1
+                    for i in reversed(range(len(dims))):
+                        index += xs[i] * product
+                        product *= dims[i]
+                    row.append(index)
+                column.append(tuple(row))
+            columns.append(tuple(column))
+
+        return tuple(
+            tuple(tuple(columns[a][pol][t] for a in range(len(action_maps))) for t in range(horizon))
+            for pol in range(num_policies)
+        )
 
     def _get_default_params(self) -> dict[str, Any] | None:
         method = self.inference_algo

--- a/pymdp/control.py
+++ b/pymdp/control.py
@@ -5,8 +5,10 @@
 """Policy construction, expected free energy, and action sampling utilities."""
 
 import itertools
+import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
+from collections import OrderedDict
 from typing import Sequence
 from functools import partial
 from jax import lax, vmap, nn
@@ -18,11 +20,40 @@ import equinox as eqx
 from pymdp.maths import factor_dot, log_stable, stable_entropy, stable_xlogx, spm_wnorm
 from pymdp import utils
 
-def _to_nested_tuple(x):
-    """Recursively convert nested lists/tuples to nested tuples, for hashable-by-value storage."""
-    if isinstance(x, (list, tuple)):
-        return tuple(_to_nested_tuple(v) for v in x)
-    return x
+_POLICY_ARR_CACHE_MAXSIZE = 128
+_policy_arr_cache: "OrderedDict[tuple, Array]" = OrderedDict()
+
+def _materialize_policy_arr(policy_tup: tuple, dtype: jnp.dtype) -> Array:
+    """
+    Cache keyed on `(policy_tup, dtype)`, both hashable-by-value: repeated `Policies`
+    construction with the same logical policy table (e.g. one fresh `Agent` per
+    training/eval step) reuses the same materialized array instead of rebuilding it on
+    every `policy_arr` access, which otherwise showed up as a measurable per-call
+    regression in `Agent.infer_policies` (non-jitted, reads `policy_arr` eagerly).
+
+    Deliberately NOT a plain `functools.lru_cache`: if this is called while
+    `Agent.policies` is accessed inside an active `jax.jit`/`lax.scan` trace (e.g.
+    `si_policy_search`, which is jitted end-to-end), `jnp.array(...)` returns a JAX
+    tracer that's only valid within that specific trace. A cache keyed purely on the
+    hashable `(policy_tup, dtype)` -- identical across trace boundaries -- would hand
+    that stale tracer back to a later, unrelated trace, corrupting it
+    (`UnexpectedTracerError`). So only concrete (non-tracer) results get cached; a
+    tracer is always recomputed fresh and never stored.
+    """
+    key = (policy_tup, dtype)
+    cached = _policy_arr_cache.get(key)
+    if cached is not None:
+        _policy_arr_cache.move_to_end(key)
+        return cached
+
+    arr = jnp.array(policy_tup, dtype=dtype)
+    if isinstance(arr, jax.core.Tracer):
+        return arr
+
+    _policy_arr_cache[key] = arr
+    if len(_policy_arr_cache) > _POLICY_ARR_CACHE_MAXSIZE:
+        _policy_arr_cache.popitem(last=False)
+    return arr
 
 
 class Policies(eqx.Module):
@@ -44,16 +75,20 @@ class Policies(eqx.Module):
             self._policy_tup = policy_arr
             self.num_policies = len(policy_arr)
             self.horizon = len(policy_arr[0])
-            self._dtype = jnp.int32
+            # normalize to an `np.dtype` instance (not a bare type like `jnp.int32`), so
+            # that a tuple-constructed and an array-constructed `Policies` holding the
+            # same logical dtype hash equal, not just `==`-compare equal; respect x64
+            # config the same way JAX's own default int dtype does.
+            self._dtype = jnp.dtype(jax.dtypes.canonicalize_dtype(jnp.int64))
         else:
             self.num_policies = policy_arr.shape[0]
             self.horizon = policy_arr.shape[1]
-            self._dtype = policy_arr.dtype
-            self._policy_tup = _to_nested_tuple(policy_arr.tolist())
+            self._dtype = jnp.dtype(policy_arr.dtype)
+            self._policy_tup = utils.to_nested_tuple(policy_arr.tolist())
 
     @property
     def policy_arr(self) -> Array:
-        return jnp.array(self._policy_tup, dtype=self._dtype)
+        return _materialize_policy_arr(self._policy_tup, self._dtype)
 
     def __getitem__(self, idx: int) -> Array:
         return self.policy_arr[idx]
@@ -199,7 +234,11 @@ def construct_policies(
     """
 
     policies_tup = _construct_policies_tuple(num_states, num_controls, policy_len, control_fac_idx)
-    return jnp.array(policies_tup, dtype=jnp.int32)
+    # respect x64 config the same way `Policies.__init__`'s tuple branch does, rather than
+    # hardcoding int32 -- `upstream/main`'s original implementation left dtype unspecified
+    # and so already respected x64 via jnp's default int inference; hardcoding int32 here
+    # would silently downgrade x64 users, exactly the class of bug fixed in `Policies.__init__`.
+    return jnp.array(policies_tup, dtype=jnp.dtype(jax.dtypes.canonicalize_dtype(jnp.int64)))
 
 
 def _construct_policies_tuple(

--- a/pymdp/control.py
+++ b/pymdp/control.py
@@ -25,20 +25,12 @@ _policy_arr_cache: "OrderedDict[tuple, Array]" = OrderedDict()
 
 def _materialize_policy_arr(policy_tup: tuple, dtype: jnp.dtype) -> Array:
     """
-    Cache keyed on `(policy_tup, dtype)`, both hashable-by-value: repeated `Policies`
-    construction with the same logical policy table (e.g. one fresh `Agent` per
-    training/eval step) reuses the same materialized array instead of rebuilding it on
-    every `policy_arr` access, which otherwise showed up as a measurable per-call
-    regression in `Agent.infer_policies` (non-jitted, reads `policy_arr` eagerly).
+    LRU cache for `policy_arr` materialization, keyed on `(policy_tup, dtype)`.
 
-    Deliberately NOT a plain `functools.lru_cache`: if this is called while
-    `Agent.policies` is accessed inside an active `jax.jit`/`lax.scan` trace (e.g.
-    `si_policy_search`, which is jitted end-to-end), `jnp.array(...)` returns a JAX
-    tracer that's only valid within that specific trace. A cache keyed purely on the
-    hashable `(policy_tup, dtype)` -- identical across trace boundaries -- would hand
-    that stale tracer back to a later, unrelated trace, corrupting it
-    (`UnexpectedTracerError`). So only concrete (non-tracer) results get cached; a
-    tracer is always recomputed fresh and never stored.
+    Not a plain `functools.lru_cache`: under an active `jax.jit`/`lax.scan` trace,
+    `jnp.array(...)` returns a tracer valid only in that trace. Caching it would leak
+    a stale tracer into later, unrelated eager code (`UnexpectedTracerError`), so only
+    concrete results are cached -- a tracer is always recomputed and never stored.
     """
     key = (policy_tup, dtype)
     cached = _policy_arr_cache.get(key)
@@ -75,10 +67,8 @@ class Policies(eqx.Module):
             self._policy_tup = policy_arr
             self.num_policies = len(policy_arr)
             self.horizon = len(policy_arr[0])
-            # normalize to an `np.dtype` instance (not a bare type like `jnp.int32`), so
-            # that a tuple-constructed and an array-constructed `Policies` holding the
-            # same logical dtype hash equal, not just `==`-compare equal; respect x64
-            # config the same way JAX's own default int dtype does.
+            # np.dtype instance (not a bare type) so tuple- and array-constructed
+            # Policies hash equal, not just ==-equal; respects x64 config.
             self._dtype = jnp.dtype(jax.dtypes.canonicalize_dtype(jnp.int64))
         else:
             self.num_policies = policy_arr.shape[0]
@@ -234,10 +224,8 @@ def construct_policies(
     """
 
     policies_tup = _construct_policies_tuple(num_states, num_controls, policy_len, control_fac_idx)
-    # respect x64 config the same way `Policies.__init__`'s tuple branch does, rather than
-    # hardcoding int32 -- `upstream/main`'s original implementation left dtype unspecified
-    # and so already respected x64 via jnp's default int inference; hardcoding int32 here
-    # would silently downgrade x64 users, exactly the class of bug fixed in `Policies.__init__`.
+    # Respect x64 config instead of hardcoding int32, which would silently
+    # downgrade precision for jax_enable_x64 users.
     return jnp.array(policies_tup, dtype=jnp.dtype(jax.dtypes.canonicalize_dtype(jnp.int64)))
 
 

--- a/pymdp/control.py
+++ b/pymdp/control.py
@@ -18,23 +18,46 @@ import equinox as eqx
 from pymdp.maths import factor_dot, log_stable, stable_entropy, stable_xlogx, spm_wnorm
 from pymdp import utils
 
+def _to_nested_tuple(x):
+    """Recursively convert nested lists/tuples to nested tuples, for hashable-by-value storage."""
+    if isinstance(x, (list, tuple)):
+        return tuple(_to_nested_tuple(v) for v in x)
+    return x
+
+
 class Policies(eqx.Module):
-    """ 
-    A class for storing an array of policies and its properties
-    
     """
-    policy_arr: Array
+    A class for storing an array of policies and its properties
+
+    """
+    _policy_tup: tuple = eqx.field(static=True)
+    _dtype: jnp.dtype = eqx.field(static=True)
     horizon: int = eqx.field(static=True)
     num_policies: int = eqx.field(static=True)
 
-    def __init__(self, policy_arr: Array) -> None:
-        self.num_policies = policy_arr.shape[0]
-        self.horizon = policy_arr.shape[1]
-        self.policy_arr = policy_arr
-    
+    def __init__(self, policy_arr: Array | tuple) -> None:
+        if isinstance(policy_arr, tuple):
+            # Already a concrete nested tuple (e.g. from `_construct_policies_tuple`).
+            # Building it never invoked a JAX primitive, so it's safe to use directly
+            # even if this constructor is itself being called while `Agent.__init__` is
+            # traced under `jax.jit` -- there's no array here to concretize.
+            self._policy_tup = policy_arr
+            self.num_policies = len(policy_arr)
+            self.horizon = len(policy_arr[0])
+            self._dtype = jnp.int32
+        else:
+            self.num_policies = policy_arr.shape[0]
+            self.horizon = policy_arr.shape[1]
+            self._dtype = policy_arr.dtype
+            self._policy_tup = _to_nested_tuple(policy_arr.tolist())
+
+    @property
+    def policy_arr(self) -> Array:
+        return jnp.array(self._policy_tup, dtype=self._dtype)
+
     def __getitem__(self, idx: int) -> Array:
         return self.policy_arr[idx]
-    
+
     def __len__(self) -> int:
         return self.num_policies
     
@@ -175,6 +198,27 @@ def construct_policies(
         Policy matrix with shape `(num_policies, policy_len, num_factors)`.
     """
 
+    policies_tup = _construct_policies_tuple(num_states, num_controls, policy_len, control_fac_idx)
+    return jnp.array(policies_tup, dtype=jnp.int32)
+
+
+def _construct_policies_tuple(
+    num_states: Sequence[int],
+    num_controls: Sequence[int] | None = None,
+    policy_len: int = 1,
+    control_fac_idx: Sequence[int] | None = None,
+) -> tuple:
+    """
+    Pure-Python (no JAX operations) combinatorial construction of the policy table, as a
+    nested tuple of shape `(num_policies, policy_len, num_factors)`.
+
+    `num_states`/`num_controls`/`policy_len`/`control_fac_idx` are always plain Python
+    values (never traced), so this never invokes a JAX primitive. That makes it safe to
+    call even while `Agent.__init__` is itself being traced under `jax.jit`, unlike
+    building the result via `jnp.array`/`jnp.stack` first: converting a traced array back
+    with `.tolist()` raises `ConcretizationTypeError`, since `.tolist()` requires a
+    concrete value that doesn't exist until the trace finishes.
+    """
     num_factors = len(num_states)
     if control_fac_idx is None:
         if num_controls is not None:
@@ -184,14 +228,14 @@ def construct_policies(
 
     if num_controls is None:
         num_controls = [num_states[c_idx] if c_idx in control_fac_idx else 1 for c_idx in range(num_factors)]
-        
-    x = num_controls * policy_len
-    policies = list(itertools.product(*[list(range(i)) for i in x]))
-    
-    for pol_i in range(len(policies)):
-        policies[pol_i] = jnp.array(policies[pol_i]).reshape(policy_len, num_factors)
 
-    return jnp.stack(policies)
+    x = num_controls * policy_len
+    flat_policies = itertools.product(*[range(i) for i in x])
+
+    return tuple(
+        tuple(flat[t * num_factors : (t + 1) * num_factors] for t in range(policy_len))
+        for flat in flat_policies
+    )
 
 
 def update_posterior_policies(

--- a/pymdp/utils.py
+++ b/pymdp/utils.py
@@ -24,6 +24,13 @@ from typing import (
 )
 
 
+def to_nested_tuple(x):
+    """Recursively convert nested lists/tuples to nested tuples, for hashable-by-value storage."""
+    if isinstance(x, (list, tuple)):
+        return tuple(to_nested_tuple(v) for v in x)
+    return x
+
+
 def norm_dist(dist: Array) -> Array:
     """Normalizes a Categorical probability distribution.
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 
 def pytest_configure(config):
     """
@@ -25,9 +24,3 @@ def pytest_configure(config):
     # Enable JAX compilation cache for faster repeated runs
     if 'JAX_COMPILATION_CACHE_DIR' not in os.environ:
         os.environ['JAX_COMPILATION_CACHE_DIR'] = '.jax_cache'
-
-    warnings.filterwarnings(
-        "ignore",
-        message=r"A JAX array is being set as static!.*",
-        category=UserWarning,
-    )

--- a/test/test_agent_jax.py
+++ b/test/test_agent_jax.py
@@ -916,12 +916,10 @@ class TestAgentJax(unittest.TestCase):
 
 class TestPoliciesTupleAgentEquivalence(unittest.TestCase):
     """
-    Regression coverage for pymdp#346 / PR#416 (hashable-tuple `Policies`) at the
-    `Agent` level: verifies `Agent._construct_flattend_policies_tuple` against the old,
-    still-present array-based `_construct_flattend_policies` across several
-    `B_action_dependencies` configurations (including conorheins's own mutation-testing
-    config from the PR review, and a `policy_len > 1` case), and that the fix actually
-    delivers on its motivating point -- hashability of `Agent.policies`, including as a
+    Regression coverage for pymdp#346 (hashable-tuple `Policies`) at the `Agent` level:
+    verifies `Agent._construct_flattend_policies_tuple` against the old, still-present
+    array-based `_construct_flattend_policies` across several `B_action_dependencies`
+    configurations, and that `Agent.policies` is actually hashable, including as a
     static `jax.jit` argument.
     """
 
@@ -932,7 +930,7 @@ class TestPoliciesTupleAgentEquivalence(unittest.TestCase):
             A_dependencies=[[0], [0, 1], [0, 1, 2]], B_dependencies=[[0], [0, 1], [1, 2]],
             B_action_dependencies=[[], [0, 1], [0, 2]], policy_len=1,
         ),
-        # conorheins's mutation-testing config, PR #416 review
+        # mutation-tested: forward vs reversed mixed-radix order changes results here
         dict(
             num_obs=[4, 5, 2], num_states=[4, 5, 2], num_controls=[2, 3, 2],
             A_dependencies=[[0], [0, 1], [0, 1, 2]], B_dependencies=[[0], [0, 1], [1, 2]],
@@ -985,22 +983,14 @@ class TestPoliciesTupleAgentEquivalence(unittest.TestCase):
 
     def test_construct_flattend_policies_tuple_direct_unit_test(self):
         """
-        Direct, isolated unit test of `Agent._construct_flattend_policies_tuple`
-        itself, calling it (and the old array-based `_construct_flattend_policies`)
-        directly -- not exercised through full `Agent()` construction, unlike
-        `test_construct_flattend_policies_tuple_matches_old_array_builder` above.
-        conorheins's review specifically asked for "a unit test for this new
-        function's correctness"; the equivalence test above (proven via mutation
-        testing to catch bugs in this exact function) only calls it indirectly,
-        through `Agent.__init__`. This closes that precision gap.
+        Isolated unit test of `Agent._construct_flattend_policies_tuple`, calling it
+        (and the old `_construct_flattend_policies`) directly rather than through a
+        full `Agent()` build.
 
-        `action_maps` are derived from the real, untouched `_flatten_B_action_dims`
-        (via a lightweight stand-in for `self`, since that method only reads
-        `self.num_controls_multi`) rather than hand-written, so there's nothing here
-        that could drift from what real `Agent` construction actually produces --
-        an earlier version of this test hand-wrote the `action_maps` dicts directly,
-        which worked but had no guarantee of staying correct if either the schema or
-        `_flatten_B_action_dims`'s behavior changed later.
+        `action_maps` are derived from the real `_flatten_B_action_dims` (via a
+        lightweight stand-in for `self`, since that method only reads
+        `self.num_controls_multi`) rather than hand-written, so this can't drift from
+        what real `Agent` construction produces.
         """
         # neither `_construct_flattend_policies` nor `_construct_flattend_policies_tuple`
         # reads `self`, so any constructed Agent works as their method owner here.
@@ -1010,9 +1000,8 @@ class TestPoliciesTupleAgentEquivalence(unittest.TestCase):
         )
 
         def real_action_maps(num_controls_multi, B_action_dependencies):
-            """Derive real action_maps via the actual _flatten_B_action_dims, using a
-            minimal stand-in for `self` and dummy-shaped B tensors (values are never
-            read, only shapes matter for the reshape logic), instead of a full Agent."""
+            """Derive real action_maps via _flatten_B_action_dims, using a minimal
+            stand-in for `self` and dummy-shaped B tensors, instead of a full Agent."""
             stand_in = SimpleNamespace(num_controls_multi=num_controls_multi)
             B = []
             for action_dependency in B_action_dependencies:
@@ -1025,8 +1014,7 @@ class TestPoliciesTupleAgentEquivalence(unittest.TestCase):
             return action_maps
 
         direct_cases = [
-            # mirrors conorheins's mutation-testing config: one empty dependency, two
-            # combined-pair dependencies, both policy_len=1 and policy_len=3
+            # one empty dependency, two combined-pair dependencies
             dict(
                 num_controls_multi=[2, 3, 2],
                 B_action_dependencies=[[], [0, 1], [0, 2]],

--- a/test/test_agent_jax.py
+++ b/test/test_agent_jax.py
@@ -7,6 +7,7 @@ __author__: Dimitrije Markovic, Conor Heins
 
 import unittest
 from functools import partial
+from types import SimpleNamespace
 
 import numpy as np
 from jax import numpy as jnp, random as jr
@@ -913,10 +914,189 @@ class TestAgentJax(unittest.TestCase):
         self.assertFalse(jnp.allclose(agent.A[0][0], E_A_filtered[0], atol=1e-6))
 
 
-        
+class TestPoliciesTupleAgentEquivalence(unittest.TestCase):
+    """
+    Regression coverage for pymdp#346 / PR#416 (hashable-tuple `Policies`) at the
+    `Agent` level: verifies `Agent._construct_flattend_policies_tuple` against the old,
+    still-present array-based `_construct_flattend_policies` across several
+    `B_action_dependencies` configurations (including conorheins's own mutation-testing
+    config from the PR review, and a `policy_len > 1` case), and that the fix actually
+    delivers on its motivating point -- hashability of `Agent.policies`, including as a
+    static `jax.jit` argument.
+    """
+
+    flatten_configs = [
+        # matches test_agent_complex_action's known-good config
+        dict(
+            num_obs=[3, 3, 2], num_states=[2, 2, 1], num_controls=[2, 2, 2],
+            A_dependencies=[[0], [0, 1], [0, 1, 2]], B_dependencies=[[0], [0, 1], [1, 2]],
+            B_action_dependencies=[[], [0, 1], [0, 2]], policy_len=1,
+        ),
+        # conorheins's mutation-testing config, PR #416 review
+        dict(
+            num_obs=[4, 5, 2], num_states=[4, 5, 2], num_controls=[2, 3, 2],
+            A_dependencies=[[0], [0, 1], [0, 1, 2]], B_dependencies=[[0], [0, 1], [1, 2]],
+            B_action_dependencies=[[], [0, 1], [0, 2]], policy_len=1,
+        ),
+        # same, with policy_len > 1
+        dict(
+            num_obs=[4, 5, 2], num_states=[4, 5, 2], num_controls=[2, 3, 2],
+            A_dependencies=[[0], [0, 1], [0, 1, 2]], B_dependencies=[[0], [0, 1], [1, 2]],
+            B_action_dependencies=[[], [0, 1], [0, 2]], policy_len=3,
+        ),
+        # 3-factor combined-dependency stress case: every B factor depends on all 3 control factors
+        dict(
+            num_obs=[2, 2, 2], num_states=[2, 2, 2], num_controls=[2, 2, 2],
+            A_dependencies=[[0], [1], [2]], B_dependencies=[[0], [1], [2]],
+            B_action_dependencies=[[0, 1, 2], [0, 1, 2], [0, 1, 2]], policy_len=1,
+        ),
+    ]
+
+    def test_construct_flattend_policies_tuple_matches_old_array_builder(self):
+        for i, cfg in enumerate(self.flatten_configs):
+            with self.subTest(i=i, policy_len=cfg["policy_len"]):
+                a_key, b_key = jr.split(jr.PRNGKey(1000 + i), 2)
+                A = utils.random_A_array(
+                    a_key, cfg["num_obs"], cfg["num_states"], A_dependencies=cfg["A_dependencies"]
+                )
+                B = utils.random_B_array(
+                    b_key, cfg["num_states"], cfg["num_controls"],
+                    B_dependencies=cfg["B_dependencies"],
+                    B_action_dependencies=cfg["B_action_dependencies"],
+                )
+                agent = Agent(
+                    A, B,
+                    A_dependencies=cfg["A_dependencies"],
+                    B_dependencies=cfg["B_dependencies"],
+                    B_action_dependencies=cfg["B_action_dependencies"],
+                    num_controls=cfg["num_controls"],
+                    policy_len=cfg["policy_len"],
+                    sampling_mode="full",
+                )
+
+                # independent ground truth: the old, still-present array-based flatten
+                # builder, fed a freshly-built (unrelated-codepath) multi-action policy array
+                policies_multi_array = control.construct_policies(
+                    agent.num_controls_multi, agent.num_controls_multi, cfg["policy_len"], None
+                )
+                reference = agent._construct_flattend_policies(policies_multi_array, agent.action_maps)
+
+                self.assertTrue(jnp.array_equal(reference, agent.policies.policy_arr))
+
+    def test_construct_flattend_policies_tuple_direct_unit_test(self):
+        """
+        Direct, isolated unit test of `Agent._construct_flattend_policies_tuple`
+        itself, calling it (and the old array-based `_construct_flattend_policies`)
+        directly -- not exercised through full `Agent()` construction, unlike
+        `test_construct_flattend_policies_tuple_matches_old_array_builder` above.
+        conorheins's review specifically asked for "a unit test for this new
+        function's correctness"; the equivalence test above (proven via mutation
+        testing to catch bugs in this exact function) only calls it indirectly,
+        through `Agent.__init__`. This closes that precision gap.
+
+        `action_maps` are derived from the real, untouched `_flatten_B_action_dims`
+        (via a lightweight stand-in for `self`, since that method only reads
+        `self.num_controls_multi`) rather than hand-written, so there's nothing here
+        that could drift from what real `Agent` construction actually produces --
+        an earlier version of this test hand-wrote the `action_maps` dicts directly,
+        which worked but had no guarantee of staying correct if either the schema or
+        `_flatten_B_action_dims`'s behavior changed later.
+        """
+        # neither `_construct_flattend_policies` nor `_construct_flattend_policies_tuple`
+        # reads `self`, so any constructed Agent works as their method owner here.
+        agent = Agent(
+            A=utils.random_A_array(jr.PRNGKey(0), [2], [2]),
+            B=utils.random_B_array(jr.PRNGKey(1), [2], [2]),
+        )
+
+        def real_action_maps(num_controls_multi, B_action_dependencies):
+            """Derive real action_maps via the actual _flatten_B_action_dims, using a
+            minimal stand-in for `self` and dummy-shaped B tensors (values are never
+            read, only shapes matter for the reshape logic), instead of a full Agent."""
+            stand_in = SimpleNamespace(num_controls_multi=num_controls_multi)
+            B = []
+            for action_dependency in B_action_dependencies:
+                if action_dependency == []:
+                    B.append(jnp.zeros(()))
+                else:
+                    dims = tuple(num_controls_multi[d] for d in action_dependency)
+                    B.append(jnp.zeros(dims))
+            _, _, action_maps = Agent._flatten_B_action_dims(stand_in, B, None, B_action_dependencies)
+            return action_maps
+
+        direct_cases = [
+            # mirrors conorheins's mutation-testing config: one empty dependency, two
+            # combined-pair dependencies, both policy_len=1 and policy_len=3
+            dict(
+                num_controls_multi=[2, 3, 2],
+                B_action_dependencies=[[], [0, 1], [0, 2]],
+                policy_len=1,
+            ),
+            dict(
+                num_controls_multi=[2, 3, 2],
+                B_action_dependencies=[[], [0, 1], [0, 2]],
+                policy_len=3,
+            ),
+            # 3-factor combined-dependency stress case: every entry depends on all 3 factors
+            dict(
+                num_controls_multi=[2, 2, 2],
+                B_action_dependencies=[[0, 1, 2], [0, 1, 2], [0, 1, 2]],
+                policy_len=1,
+            ),
+        ]
+
+        for i, cfg in enumerate(direct_cases):
+            with self.subTest(i=i, policy_len=cfg["policy_len"]):
+                action_maps = real_action_maps(cfg["num_controls_multi"], cfg["B_action_dependencies"])
+
+                policies_tup = control._construct_policies_tuple(
+                    cfg["num_controls_multi"], cfg["num_controls_multi"], cfg["policy_len"], None
+                )
+                policies_array = control.construct_policies(
+                    cfg["num_controls_multi"], cfg["num_controls_multi"], cfg["policy_len"], None
+                )
+
+                new_result = agent._construct_flattend_policies_tuple(policies_tup, action_maps)
+                reference = agent._construct_flattend_policies(policies_array, action_maps)
+
+                self.assertTrue(jnp.array_equal(reference, jnp.array(new_result, dtype=jnp.int32)))
+
+    def test_agent_policies_hash_reproducible_across_identical_construction(self):
+        """Direct regression test for pymdp#346: two freshly-built, logically-identical
+        `Agent`s must produce equal-hashing `Policies`, not just equal-valued ones."""
+        num_obs = [3]
+        num_states = [3]
+        num_controls = [3]
+        a_key, b_key = jr.split(jr.PRNGKey(7), 2)
+        A = utils.random_A_array(a_key, num_obs, num_states)
+        B = utils.random_B_array(b_key, num_states, num_controls)
+
+        agent1 = Agent(A=A, B=B, policy_len=2)
+        agent2 = Agent(A=A, B=B, policy_len=2)
+
+        self.assertEqual(agent1.policies, agent2.policies)
+        self.assertEqual(hash(agent1.policies), hash(agent2.policies))
+
+        agent3 = Agent(A=A, B=B, policy_len=3)  # different policy_len -> different table
+        self.assertNotEqual(agent1.policies, agent3.policies)
+        self.assertNotEqual(hash(agent1.policies), hash(agent3.policies))
+
+    def test_policies_usable_as_static_jit_argument(self):
+        """Passing `Policies` as a `static_argnums` jit argument raises on the old
+        array-backed implementation (unhashable jnp.ndarray field); must work now."""
+        A = utils.random_A_array(jr.PRNGKey(0), [2], [2])
+        B = utils.random_B_array(jr.PRNGKey(1), [2], [2])
+        policies = Agent(A=A, B=B).policies
+
+        @partial(jit, static_argnums=0)
+        def f(pol):
+            return pol.num_policies
+
+        self.assertEqual(f(policies), policies.num_policies)
+
 
 if __name__ == "__main__":
-    unittest.main()       
+    unittest.main()
 
 
 

--- a/test/test_control_jax.py
+++ b/test/test_control_jax.py
@@ -5,9 +5,13 @@
 __author__: Dimitrije Markovic, Conor Heins
 """
 
+import itertools
+import subprocess
+import sys
 import unittest
 
 import numpy as np
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import jax.tree_util as jtu
@@ -286,6 +290,169 @@ class TestControlJax(unittest.TestCase):
                 use_param_info_gain=True,
                 use_inductive=False,
             )
+
+def _reference_construct_policies_array(num_states, num_controls=None, policy_len=1, control_fac_idx=None):
+    """
+    Independent array-based reference for policy construction, deliberately not sharing
+    any code with `control._construct_policies_tuple`/`control.construct_policies`
+    (which now both delegate to the same tuple-building logic internally) -- exists so
+    the equivalence test below has real ground truth rather than comparing the code
+    under test against itself.
+    """
+    num_factors = len(num_states)
+    if control_fac_idx is None:
+        if num_controls is not None:
+            control_fac_idx = [f for f, n_c in enumerate(num_controls) if n_c > 1]
+        else:
+            control_fac_idx = list(range(num_factors))
+    if num_controls is None:
+        num_controls = [num_states[c_idx] if c_idx in control_fac_idx else 1 for c_idx in range(num_factors)]
+
+    x = num_controls * policy_len
+    policies = list(itertools.product(*[list(range(i)) for i in x]))
+    for pol_i in range(len(policies)):
+        policies[pol_i] = jnp.array(policies[pol_i]).reshape(policy_len, num_factors)
+    return jnp.stack(policies)
+
+
+class TestPoliciesTupleEquivalence(unittest.TestCase):
+    """
+    Regression coverage for the hashable-tuple `Policies`/`_construct_policies_tuple`
+    rework (pymdp#346 / PR#416): verifies the pure-Python tuple builders against
+    independent references, and that hashability actually holds across construction
+    paths, since neither was covered by a committed test before this.
+    """
+
+    cases = [
+        dict(num_states=[3, 3], num_controls=[3, 2], policy_len=2),
+        dict(num_states=[2, 2, 1], num_controls=[2, 2, 2], policy_len=1),
+        dict(num_states=[4], num_controls=[4], policy_len=3),
+        dict(num_states=[2, 3, 4], num_controls=None, policy_len=1),
+        dict(num_states=[2, 3, 4], num_controls=None, policy_len=1, control_fac_idx=[0, 2]),
+        dict(num_states=[5], num_controls=[5], policy_len=1),
+        dict(num_states=[2, 2], num_controls=[1, 2], policy_len=4),
+        # mirrors conorheins's mutation-testing config for issue #346 / PR #416
+        dict(num_states=[4, 5, 2], num_controls=[2, 3, 2], policy_len=1),
+        dict(num_states=[4, 5, 2], num_controls=[2, 3, 2], policy_len=3),
+    ]
+
+    def test_construct_policies_tuple_matches_reference(self):
+        for kwargs in self.cases:
+            with self.subTest(**kwargs):
+                reference = _reference_construct_policies_array(**kwargs)
+                tup = ctl_jax._construct_policies_tuple(**kwargs)
+                got = jnp.array(tup, dtype=jnp.int32)
+                self.assertEqual(reference.shape, got.shape)
+                self.assertTrue(jnp.array_equal(reference, got))
+
+    def test_construct_policies_matches_tuple_builder(self):
+        # construct_policies() itself now delegates to _construct_policies_tuple(), so
+        # this only checks the array-wrapping is faithful, not correctness of the
+        # underlying combinatorics (that's covered against the independent reference above)
+        for kwargs in self.cases:
+            with self.subTest(**kwargs):
+                tup = ctl_jax._construct_policies_tuple(**kwargs)
+                array_version = ctl_jax.construct_policies(**kwargs)
+                self.assertTrue(jnp.array_equal(array_version, jnp.array(tup, dtype=jnp.int32)))
+
+    def test_policies_array_and_tuple_construction_are_hash_and_eq_consistent(self):
+        for kwargs in self.cases:
+            with self.subTest(**kwargs):
+                array_version = ctl_jax.construct_policies(**kwargs)
+                p_from_array = ctl_jax.Policies(array_version)
+                p_from_tuple = ctl_jax.Policies(p_from_array._policy_tup)
+
+                self.assertEqual(p_from_array, p_from_tuple)
+                self.assertEqual(hash(p_from_array), hash(p_from_tuple))
+                self.assertEqual(p_from_array._dtype, p_from_tuple._dtype)
+                self.assertEqual(hash(p_from_array._dtype), hash(p_from_tuple._dtype))
+                self.assertTrue(jnp.array_equal(p_from_array.policy_arr, p_from_tuple.policy_arr))
+
+    def test_policies_hash_differs_for_different_policy_tables(self):
+        p1 = ctl_jax.Policies(ctl_jax.construct_policies(num_states=[3], num_controls=[3], policy_len=1))
+        p2 = ctl_jax.Policies(ctl_jax.construct_policies(num_states=[4], num_controls=[4], policy_len=1))
+        self.assertNotEqual(p1, p2)
+        self.assertNotEqual(hash(p1), hash(p2))
+
+    def test_policy_arr_cache_does_not_leak_tracers_across_jit_boundary(self):
+        """
+        Regression test for a tracer-leak bug found in `_materialize_policy_arr`'s
+        cache: keying purely on the hashable `(policy_tup, dtype)` (as a naive
+        `functools.lru_cache` would) means the FIRST materialization of a given
+        policy table can happen while tracing under `jax.jit`/`lax.scan` (producing a
+        JAX tracer, only valid within that specific trace) and get cached; a LATER,
+        unrelated eager access with the same key then gets handed that stale tracer
+        back, raising `jax.errors.UnexpectedTracerError` the moment it's actually used
+        in another op. This is exactly the sequence that broke `si_policy_search` in
+        practice (materialized inside its jitted planning loop first, then reused via
+        `agent.policies` in eager code afterward). The fix only caches concrete
+        (non-tracer) results; a tracer is always recomputed fresh and never stored.
+
+        Getting the order right matters: warming the cache eagerly *before* the jit
+        access (as an earlier, wrong version of this test did) never exercises the
+        cold-cache-inside-a-trace path at all, and passes even with the guard removed.
+        """
+        ctl_jax._policy_arr_cache.clear()
+
+        arr = ctl_jax.construct_policies(num_states=[3, 2], num_controls=[3, 2], policy_len=2)
+        policies = ctl_jax.Policies(arr)
+        key = (policies._policy_tup, policies._dtype)
+        self.assertNotIn(key, ctl_jax._policy_arr_cache, "test setup requires a cold cache")
+
+        # FIRST access: cold cache, happens INSIDE an active jax.jit trace -- this is
+        # the moment a naive cache would store a tracer.
+        @jax.jit
+        def access_inside_jit(policies_obj):
+            return policies_obj.policy_arr.sum()
+
+        result = access_inside_jit(policies)
+        self.assertTrue(jnp.array_equal(result, arr.sum()))
+
+        if key in ctl_jax._policy_arr_cache:
+            self.assertFalse(isinstance(ctl_jax._policy_arr_cache[key], jax.core.Tracer))
+
+        # SECOND access: eager, same key, and actually USE the returned array (merely
+        # holding a reference to a stale tracer doesn't raise -- feeding it into another
+        # op outside its original trace is what raises `UnexpectedTracerError`, mirroring
+        # `control.get_marginals`'s indexing/comparison on `agent.policies.policy_arr`).
+        eager_result = policies.policy_arr
+        self.assertFalse(isinstance(eager_result, jax.core.Tracer))
+        sliced = eager_result[:, 0, 0]
+        self.assertTrue(jnp.array_equal(sliced, arr[:, 0, 0]))
+
+    def test_construct_policies_and_tuple_policies_respect_x64_config(self):
+        """
+        Regression test for a silent x64-downgrade bug: both `construct_policies()`
+        and `Policies.__init__`'s tuple branch used to hardcode `dtype=jnp.int32`,
+        silently discarding int64 precision for users running under
+        `jax_enable_x64=True`, exactly the class of bug conorheins flagged inline on
+        `Policies.__init__` (a second, separate instance of it was found in
+        `construct_policies()` itself and fixed the same way).
+
+        Runs in a fresh subprocess, calling `jax.config.update('jax_enable_x64', True)`
+        immediately after importing `jax` and before any array/dtype operation, since
+        flipping x64 config inside this process would leak into every other test
+        sharing this pytest worker (x64 config is process-global and JAX warns
+        against toggling it after other JAX operations have already run).
+        """
+        script = (
+            "import jax; jax.config.update('jax_enable_x64', True)\n"
+            "import jax.numpy as jnp\n"
+            "from pymdp.control import Policies, construct_policies\n"
+            "arr = construct_policies(num_states=[3], num_controls=[3], policy_len=1)\n"
+            "assert arr.dtype == jnp.dtype('int64'), f'construct_policies: expected int64, got {arr.dtype}'\n"
+            "p = Policies(((0,), (1,), (2,)))\n"
+            "assert p._dtype == jnp.dtype('int64'), f'Policies tuple branch: expected int64, got {p._dtype}'\n"
+            "assert p.policy_arr.dtype == jnp.dtype('int64')\n"
+            "print('OK')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True, text=True, timeout=60,
+        )
+        self.assertEqual(result.returncode, 0, f"stdout: {result.stdout}\nstderr: {result.stderr}")
+        self.assertIn("OK", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_control_jax.py
+++ b/test/test_control_jax.py
@@ -318,9 +318,8 @@ def _reference_construct_policies_array(num_states, num_controls=None, policy_le
 class TestPoliciesTupleEquivalence(unittest.TestCase):
     """
     Regression coverage for the hashable-tuple `Policies`/`_construct_policies_tuple`
-    rework (pymdp#346 / PR#416): verifies the pure-Python tuple builders against
-    independent references, and that hashability actually holds across construction
-    paths, since neither was covered by a committed test before this.
+    rework (pymdp#346): verifies the pure-Python tuple builders against independent
+    references, and that hashability holds across construction paths.
     """
 
     cases = [
@@ -331,7 +330,6 @@ class TestPoliciesTupleEquivalence(unittest.TestCase):
         dict(num_states=[2, 3, 4], num_controls=None, policy_len=1, control_fac_idx=[0, 2]),
         dict(num_states=[5], num_controls=[5], policy_len=1),
         dict(num_states=[2, 2], num_controls=[1, 2], policy_len=4),
-        # mirrors conorheins's mutation-testing config for issue #346 / PR #416
         dict(num_states=[4, 5, 2], num_controls=[2, 3, 2], policy_len=1),
         dict(num_states=[4, 5, 2], num_controls=[2, 3, 2], policy_len=3),
     ]
@@ -376,21 +374,14 @@ class TestPoliciesTupleEquivalence(unittest.TestCase):
 
     def test_policy_arr_cache_does_not_leak_tracers_across_jit_boundary(self):
         """
-        Regression test for a tracer-leak bug found in `_materialize_policy_arr`'s
-        cache: keying purely on the hashable `(policy_tup, dtype)` (as a naive
-        `functools.lru_cache` would) means the FIRST materialization of a given
-        policy table can happen while tracing under `jax.jit`/`lax.scan` (producing a
-        JAX tracer, only valid within that specific trace) and get cached; a LATER,
-        unrelated eager access with the same key then gets handed that stale tracer
-        back, raising `jax.errors.UnexpectedTracerError` the moment it's actually used
-        in another op. This is exactly the sequence that broke `si_policy_search` in
-        practice (materialized inside its jitted planning loop first, then reused via
-        `agent.policies` in eager code afterward). The fix only caches concrete
-        (non-tracer) results; a tracer is always recomputed fresh and never stored.
+        Regression test for a tracer-leak bug in `_materialize_policy_arr`'s cache: a
+        naive `functools.lru_cache` keyed on `(policy_tup, dtype)` could cache a JAX
+        tracer produced by a first access inside a `jax.jit`/`lax.scan` trace, then
+        hand that stale tracer to a later, unrelated eager access, raising
+        `UnexpectedTracerError`. The fix only caches concrete results.
 
-        Getting the order right matters: warming the cache eagerly *before* the jit
-        access (as an earlier, wrong version of this test did) never exercises the
-        cold-cache-inside-a-trace path at all, and passes even with the guard removed.
+        Order matters here: the cold cache access must happen inside the jit trace
+        first, otherwise this test never exercises the bug path.
         """
         ctl_jax._policy_arr_cache.clear()
 
@@ -424,16 +415,10 @@ class TestPoliciesTupleEquivalence(unittest.TestCase):
         """
         Regression test for a silent x64-downgrade bug: both `construct_policies()`
         and `Policies.__init__`'s tuple branch used to hardcode `dtype=jnp.int32`,
-        silently discarding int64 precision for users running under
-        `jax_enable_x64=True`, exactly the class of bug conorheins flagged inline on
-        `Policies.__init__` (a second, separate instance of it was found in
-        `construct_policies()` itself and fixed the same way).
+        discarding int64 precision under `jax_enable_x64=True`.
 
-        Runs in a fresh subprocess, calling `jax.config.update('jax_enable_x64', True)`
-        immediately after importing `jax` and before any array/dtype operation, since
-        flipping x64 config inside this process would leak into every other test
-        sharing this pytest worker (x64 config is process-global and JAX warns
-        against toggling it after other JAX operations have already run).
+        Runs in a fresh subprocess since x64 is process-global config and can't be
+        toggled inline without leaking into other tests in the same pytest worker.
         """
         script = (
             "import jax; jax.config.update('jax_enable_x64', True)\n"


### PR DESCRIPTION
Fixes #346

`Agent.policies` is marked `static=True` (#345) to support `vmap`/`scan` over a batched Agent (#227), since `policies` has no batch dimension. But `Policies.policy_arr` is a real `jnp.ndarray`, so the static partition ends up identity-based instead of value-based, and every fresh `Agent` construction is a cache miss under `eqx.filter_jit`.

This backs `Policies` with a hashable tuple instead, exposing `policy_arr` as a property that materializes a JAX array on access. `Agent.policies` stays static, but the static partition is now hashable by value.

Constructing an `Agent` inside an active `jax.jit` trace broke the first version of this, since a traced array can't be converted to a concrete tuple mid-trace. Traced this to `construct_policies()` converting to JAX arrays earlier than necessary. Added Python tuple builders that defer the JAX conversion to the property/return boundary.

## Testing

- `hash(Policies)` now works (`main` raises `TypeError: unhashable type 'ArrayImpl'`)
- `jax.jit(f, static_argnums=0)` with a `Policies` argument now works (`main` raises `ValueError: Non-hashable static arguments...`)
- The "A JAX array is being set as static!" warning no longer appears
- `vmap`/`scan`/slicing over a batched Agent still work (#227)
- New construction path verified equivalent to the old output.
- No memory regression observed under repeated Agent construction (CPU and GPU) or in a compiled workload mirroring the planning loop's access pattern (CPU). At larger policy-table sizes, the tuple implementation showed lower peak memory usage than the current implementation during repeated construction.
- Full test suite: 305 passed, 1 skipped, 1 pre-existing unrelated error