### PR TITLE
ci: exclude jaxlib 0.10.2 in test env (XLA compile hang on Linux x86-64)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,13 @@ dev = [
 ]
 
 test = [
+    # Exclude jaxlib/jax 0.10.2: its Linux x86-64 CPU (XLA) build hangs compiling the
+    # JIT cell in examples/advanced/infer_states_optimization/methods_test.ipynb (>2000s,
+    # uninterruptible), reddening the CI notebook step on unrelated PRs. 0.10.1 is the last
+    # known-good (main was green on it). Scoped to the test env only so published deps stay
+    # unconstrained. Remove once the upstream regression is fixed.
+    "jax!=0.10.2",
+    "jaxlib!=0.10.2",
     # Keep ipykernel<7 while mkdocs-jupyter requires ipykernel>6,<7.
     "ipykernel>=6.29.0,<7",
     "jupyter>=1.1.1",


### PR DESCRIPTION
## Problem

CI (`Test` workflow → notebook step) is failing on every PR to `main`, but **not because of any PR's code**. The unit-test step passes (297 passed on all Python versions); the only failure is a single notebook cell:

```
FAILED examples/advanced/infer_states_optimization/methods_test.ipynb::Cell 9
Cell 9: Timeout of 2000 seconds exceeded while executing cell.
```

That cell is a `jax.jit` compilation of a vmapped factorized fixed-point-iteration over a padded `A` tensor. It **hangs at compile time inside XLA** (uninterruptible; "failed to interrupt kernel"), blowing past nbval's 2000s per-cell timeout — which is why each job burns ~47 min before failing.

## Root cause: jaxlib 0.10.2 (Linux x86-64 CPU/XLA) regression

CI resolves dependencies fresh each run so the installed stack drifts over time. Comparing the last green `main` run to the failing runs, the **only** relevant delta is:

| | green `main` | failing |
|---|---|---|
| jax / jaxlib | **0.10.1** | **0.10.2** |

The notebook itself is fine — it runs Cell 9 in **~0.3 s** locally on both jax 0.9.1 and 0.10.2 on macOS/arm64. The hang is specific to the **Linux x86-64 jaxlib 0.10.2 CPU build** (jaxlib ships a per-platform XLA). Closest upstream precedent is the CPU tiled-fusion-emitter high-rank blowup in [openxla/xla#41173](https://github.com/openxla/xla/issues/41173) (our padded `A` is rank 7); an upstream report is being prepared separately.

## Fix

Exclude `jax`/`jaxlib` `0.10.2` **in the `test` dependency-group only**, so the published runtime constraints stay untouched and downstream users are unaffected. Resolves to the last known-good `0.10.1` on Python 3.11–3.14, and will auto-adopt `0.10.3+` once the regression is fixed upstream.

This is intentionally surgical. It does **not** switch CI to a frozen lockfile — testing against latest deps is what surfaced this regression in the first place, and freezing that is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
