### PR TITLE
ci: disable XLA ynn fusion in test workflows; drop jaxlib 0.10.2 exclusion

### DIFF
--- a/.github/workflows/manual-branch-nightly.yaml
+++ b/.github/workflows/manual-branch-nightly.yaml
@@ -23,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      # Work around a jaxlib 0.10.2+ XLA:CPU bug (__ynn_fusion crash/hang on rank>=7
+      # broadcast-multiply-reduce). See https://github.com/jax-ml/jax/issues/39257.
+      # Remove once fixed upstream.
+      XLA_FLAGS: --xla_cpu_experimental_ynn_fusion_type=
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -8,6 +8,11 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-latest
+    env:
+      # Work around a jaxlib 0.10.2+ XLA:CPU bug (__ynn_fusion crash/hang on rank>=7
+      # broadcast-multiply-reduce). See https://github.com/jax-ml/jax/issues/39257.
+      # Remove once fixed upstream.
+      XLA_FLAGS: --xla_cpu_experimental_ynn_fusion_type=
     strategy:
       matrix:
         python-version: ["3.14"]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Work around a jaxlib 0.10.2+ XLA:CPU bug: the default-on __ynn_fusion path
+      # crashes/hangs on rank>=7 broadcast-multiply-reduce kernels on x86-64, which
+      # stalls the padded-A jit cells in the infer_states notebooks for >2000s.
+      # See https://github.com/jax-ml/jax/issues/39257. Remove once fixed upstream.
+      XLA_FLAGS: --xla_cpu_experimental_ynn_fusion_type=
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,13 +42,6 @@ dev = [
 ]
 
 test = [
-    # Exclude jaxlib/jax 0.10.2: its Linux x86-64 CPU (XLA) build hangs compiling the
-    # JIT cell in examples/advanced/infer_states_optimization/methods_test.ipynb (>2000s,
-    # uninterruptible), reddening the CI notebook step on unrelated PRs. 0.10.1 is the last
-    # known-good (main was green on it). Scoped to the test env only so published deps stay
-    # unconstrained. Remove once the upstream regression is fixed.
-    "jax!=0.10.2",
-    "jaxlib!=0.10.2",
     # Keep ipykernel<7 while mkdocs-jupyter requires ipykernel>6,<7.
     "ipykernel>=6.29.0,<7",
     "jupyter>=1.1.1",


### PR DESCRIPTION
## Problem

jaxlib **0.10.2+** enables XLA:CPU's `__ynn_fusion` path by default, which crashes or hangs on rank≥7 broadcast-multiply-reduce kernels on Linux x86-64 — upstream report with a 10-line repro, gdb backtrace (`slinky::optimize_dims` via `ynn::make_transpose_impl`), and full version/hardware matrix: [jax-ml/jax#39257](https://github.com/jax-ml/jax/issues/39257).

In our CI this stalls the padded-`A` jit cells of `examples/advanced/infer_states_optimization/methods_test.ipynb` past nbval's 2000 s timeout, reddening unrelated PRs. #417 excluded 0.10.2 in the test group, but the same bug shipped again in 0.11.0 (re-reddening #416) — version exclusion is whack-a-mole.

## Fix

Set `XLA_FLAGS=--xla_cpu_experimental_ynn_fusion_type=` (empty ⇒ ynn fusion disabled) at the job level in the three workflows that execute jax code (`test.yaml`, `nightly-tests.yaml`, `manual-branch-nightly.yaml`), and **remove the `!=0.10.2` exclusions** from `pyproject.toml` so CI resumes resolving the latest jax/jaxlib (currently 0.11.0).

Verified: the flag fixes the hang/crash on 0.10.2 and 0.11.0 for both the minimal repro and the full notebook workload (QEMU x86-64 + bare-metal EPYC 9554), and parses cleanly back to 0.10.1. `setup.cfg` is untouched (published deps were never constrained).

Notes:
- Trade-off: CI stops exercising XLA's default CPU fusion path (users still run it). Acceptable vs. red CI or frozen versions.
- Built-in tripwire: if a future jaxlib removes the experimental flag, XLA hard-errors on unknown flags → CI goes loudly red instead of silently carrying a stale workaround.
- Remove the env var from all three workflows once the upstream fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)