### PR TITLE
fix(legacy): make deterministic action/policy tie-breaks reproducible

### DIFF
--- a/pymdp/legacy/control.py
+++ b/pymdp/legacy/control.py
@@ -1014,7 +1014,7 @@ def get_num_controls_from_policies(policies):
     return list(np.max(np.vstack(policies), axis = 0) + 1)
     
 
-def sample_action(q_pi, policies, num_controls, action_selection="deterministic", alpha = 16.0):
+def sample_action(q_pi, policies, num_controls, action_selection="deterministic", alpha = 16.0, seed=None):
     """
     Computes the marginal posterior over actions and then samples an action from it, one action per control factor.
 
@@ -1057,7 +1057,7 @@ def sample_action(q_pi, policies, num_controls, action_selection="deterministic"
 
         # Either you do this:
         if action_selection == 'deterministic':
-            selected_policy[factor_i] = select_highest(action_marginals[factor_i])
+            selected_policy[factor_i] = select_highest(action_marginals[factor_i], seed=seed)
         elif action_selection == 'stochastic':
             log_marginal_f = spm_log_single(action_marginals[factor_i])
             p_actions = softmax(log_marginal_f * alpha)
@@ -1123,7 +1123,7 @@ def _sample_action_test(q_pi, policies, num_controls, action_selection="determin
 
     return selected_policy, p_actions
 
-def sample_policy(q_pi, policies, num_controls, action_selection="deterministic", alpha = 16.0):
+def sample_policy(q_pi, policies, num_controls, action_selection="deterministic", alpha = 16.0, seed=None):
     """
     Samples a policy from the posterior over policies, taking the action (per control factor) entailed by the first timestep of the selected policy.
 
@@ -1153,7 +1153,7 @@ def sample_policy(q_pi, policies, num_controls, action_selection="deterministic"
     num_factors = len(num_controls)
 
     if action_selection == "deterministic":
-        policy_idx = select_highest(q_pi)
+        policy_idx = select_highest(q_pi, seed=seed)
     elif action_selection == "stochastic":
         log_qpi = spm_log_single(q_pi)
         p_policies = softmax(log_qpi * alpha)
@@ -1212,13 +1212,15 @@ def _sample_policy_test(q_pi, policies, num_controls, action_selection="determin
     return selected_policy, p_policies
 
 
-def select_highest(options_array):
+def select_highest(options_array, seed=None):
     """
-    Selects the highest value among the provided ones. If the higher value is more than once and they're closer than 1e-5, a random choice is made.
+    Selects the highest value among the provided ones. If the higher value is more than once and they're closer than 1e-8, a random choice is made.
     Parameters
     ----------
     options_array: ``numpy.ndarray``
         The array to examine
+    seed: ``int``, optional
+        Seed to make the tie-break random choice reproducible. If ``None``, uses the global NumPy RNG.
 
     Returns
     -------
@@ -1229,7 +1231,8 @@ def select_highest(options_array):
                     abs(options_with_idx[:, 1] - np.amax(options_with_idx[:, 1])) <= 1e-8][:, 0]
     if len(same_prob) > 1:
         # If some of the most likely actions have nearly equal probability, sample from this subset of actions, instead of using argmax
-        return int(same_prob[np.random.choice(len(same_prob))])
+        rng = np.random.default_rng(seed)
+        return int(same_prob[rng.choice(len(same_prob))])
 
     return int(same_prob[0])
 

--- a/test/test_control.py
+++ b/test/test_control.py
@@ -1654,10 +1654,10 @@ class TestControl(unittest.TestCase):
 
         seeds = [1923, 48323]
 
-        sampled_action = control._sample_action_test(q_pi, policies, num_controls, action_selection="deterministic", seed=seeds[0])
+        sampled_action = control.sample_action(q_pi, policies, num_controls, action_selection="deterministic", seed=seeds[0])
         self.assertEqual(sampled_action[0], 0)
 
-        sampled_action = control._sample_action_test(q_pi, policies, num_controls, action_selection="deterministic", seed=seeds[1])
+        sampled_action = control.sample_action(q_pi, policies, num_controls, action_selection="deterministic", seed=seeds[1])
         self.assertEqual(sampled_action[0], 1)
     
     def test_deterministic_policy_selection_equal_value(self):
@@ -1673,10 +1673,10 @@ class TestControl(unittest.TestCase):
 
         seeds = [1923, 48323]
 
-        sampled_action = control._sample_policy_test(q_pi, policies, num_controls, action_selection="deterministic", seed=seeds[0])
+        sampled_action = control.sample_policy(q_pi, policies, num_controls, action_selection="deterministic", seed=seeds[0])
         self.assertEqual(sampled_action[0], 1)
 
-        sampled_action = control._sample_policy_test(q_pi, policies, num_controls, action_selection="deterministic", seed=seeds[1])
+        sampled_action = control.sample_policy(q_pi, policies, num_controls, action_selection="deterministic", seed=seeds[1])
         self.assertEqual(sampled_action[0], 2)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The legacy API's `action_selection="deterministic"` path is not actually deterministic on ties: `select_highest` (`pymdp/legacy/control.py`) breaks exact (within 1e-8) ties via the module-global NumPy RNG (`np.random.choice`), so a seeded run is not reproducible and the call is not thread-safe.

This PR threads an optional `seed` parameter through the production `select_highest`, `sample_action` and `sample_policy` functions, using a local `np.random.default_rng(seed)` for the tie-break (the same pattern the existing `_select_highest_test` helper already used). Supplying a seed makes the result reproducible; `seed=None` keeps current behavior for backward compatibility.

It also corrects the `select_highest` docstring, which claimed a 1e-5 tolerance while the code uses 1e-8.

Finally, the two deterministic tie-break tests were rewritten to exercise the **real production paths** (`sample_action`/`sample_policy` with `seed=`) instead of the test-only `_sample_action_test`/`_sample_policy_test` helpers — those helpers were dead code never referenced by production, so the nondeterministic behavior had zero real coverage.

## Verification

- Legacy import with only the required deps confirmed that `opt_einsum` is a required (currently undeclared) import — separate concern, not part of this PR.
- `select_highest` tie behavior validated in isolation: same seed → same result; different seeds → subset of the tied indices; non-tie → argmax.
- Production `sample_action`/`sample_policy` with `seed=` reproduce exactly the values the old tests asserted (action: seed 1923 → 0, 48323 → 1; policy: seed 1923 → 1, 48323 → 2).
- Full `test/test_control.py` passes: **23 passed**.

## Tests

- `test/test_control.py::TestControl::test_deterministic_action_sampling_equal_value`
- `test/test_control.py::TestControl::test_deterministic_policy_selection_equal_value`

Both now call the production functions with an explicit seed.
