### PR TITLE
chore(deps): declare opt_einsum and jaxtyping as direct dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
     'seaborn>=0.11.1',
     'mctx>=0.0.5',
     'networkx>=3.3',
+    'opt_einsum>=3.3',
+    'jaxtyping>=0.2',
 ]
 
 [dependency-groups]

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,8 @@ install_requires =
     seaborn>=0.11.1
     mctx>=0.0.5
     networkx>=3.3
+    opt_einsum>=3.3
+    jaxtyping>=0.2
 include_package_data = True
 
 [options.extras_require]


### PR DESCRIPTION
chore(deps): declare opt_einsum and jaxtyping as direct dependencies

pymdp/maths.py imports `from opt_einsum import contract` and several modules
(pymdp/agent.py, algos.py, control.py, maths.py) import `from jaxtyping import
Array`, but neither package is listed in `dependencies` in pyproject.toml or
`install_requires` in setup.cfg. They currently only work because they happen
to be pulled in transitively by jax/equinox.

This is a real packaging fragility, not just hygiene: installing the package
fresh without those transitive packages present fails at import. Verified
locally: with only the declared deps installed, `import pymdp.legacy` raised
`ModuleNotFoundError: No module named 'opt_einsum'`; adding opt_einsum restored
import. jaxtyping is imported directly too, so it is declared for the same
reason (independent of any transitive availability).

This adds both to pyproject.toml and setup.cfg with a conservative version
floor matching the surrounding declarations.
