### PR TITLE
deps: fix ruff version and make local dev setup match CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,4 +20,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v6
     - name: Analysing the code with ruff
-      run: uvx ruff check
+      # Bound ruff to the 0.15.x series: 0.16.0 broadened the default rule set,
+      # which flags a large amount of pre-existing code. Staying on <0.16 keeps
+      # lint green while still picking up 0.15.x patch fixes. Bump the ceiling
+      # deliberately when ready to adopt the newer rules.
+      run: uvx 'ruff>=0.15,<0.16' check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,13 @@
 repos:
   - repo: local
     hooks:
+      - id: ruff
+        name: ruff lint
+        # Uses the ruff bounded in the `dev` dependency group, matching CI.
+        entry: uv run --group dev ruff check --force-exclude
+        language: system
+        types_or: [python, pyi, jupyter]
+        require_serial: true
       - id: sanitize-notebooks
         name: sanitize notebooks by tier
         entry: uv run --group dev python scripts/notebook_precommit.py sanitize

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dev = [
     "nbformat>=5.10.4",
     "nbstripout>=0.8.2",
     "pre-commit>=4.2.0",
+    # Bound to <0.16: 0.16.0 broadened ruff's default rule set. Keep this in
+    # sync with the ruff spec in .github/workflows/lint.yaml.
+    "ruff>=0.15,<0.16",
 ]
 
 test = [


### PR DESCRIPTION
Our CI lint step currently pulls the latest version of `ruff` and uses whatever defaults that brings.

This PR:
- fixes the version of `ruff` in the CI lint job
- adds `ruff` to the `dev` group of dependencies to make it less likely for local developers to have a mismatch with CI

This means that CI will be stable - and we can manually upgrade to later versions of the linter and update existing code at our own speed.