### PR TITLE
fix: label lists on multiple axes select blocks instead of diagonals

### DIFF
--- a/pymdp/distribution.py
+++ b/pymdp/distribution.py
@@ -39,21 +39,120 @@ class Distribution:
                 raise ValueError(f"When setting the tensor directly, the new shape {value.shape} must match the existing tensor shape {self._data.shape}")
         self._data = value
 
-    def get(self, batch: dict | None = None, event: dict | None = None) -> np.ndarray:
+    def get(
+        self, batch: dict | None = None, event: dict | None = None, *, pointwise: bool = False
+    ) -> np.ndarray:
+        """Read the block the labels name, in declared axis order.
+
+        Lists on several axes select the block they describe. pointwise=True
+        zips them into single points instead, as described on set.
+        """
         event_slices = self._get_slices(event, self.event_indices, self.event)
         batch_slices = self._get_slices(batch, self.batch_indices, self.batch)
 
         slices = event_slices + batch_slices
-        return self._data[tuple(slices)]
+        return self._data[self._index(slices, pointwise)]
 
     def set(
-        self, batch: dict | None = None, event: dict | None = None, values: np.ndarray | float | int | None = None
+        self,
+        batch: dict | None = None,
+        event: dict | None = None,
+        values: np.ndarray | float | int | None = None,
+        *,
+        pointwise: bool = False,
     ) -> None:
+        """Write values into the block the labels name, in declared axis order.
+
+        values is broadcast into that block by the usual numpy rules, so a
+        value whose shape is smaller than the block is repeated across it.
+        Writing lists of labels on two axes therefore fills the whole block:
+
+            transition.set(
+                event={"loc": locs}, batch={"loc": locs, "ctrl": "up"},
+                values=np.ones(4),
+            )
+
+        writes 1.0 to all 16 entries of the 4 by 4 block, because a (4,)
+        value is broadcast into every row of it. Before block selection
+        existed this same expression wrote the 4 diagonal entries. Pass
+        pointwise=True to keep that meaning: the lists are then zipped into
+        4 points and values is matched against those points instead.
+        """
         event_slices = self._get_slices(event, self.event_indices, self.event)
         batch_slices = self._get_slices(batch, self.batch_indices, self.batch)
 
         slices = event_slices + batch_slices
-        self._data[tuple(slices)] = values
+        self._data[self._index(slices, pointwise)] = values
+
+    def _index(self, slices: list[Any], pointwise: bool) -> tuple:
+        """Turn per-axis indices into a tuple that selects what the labels name.
+
+        Without lists this returns the entries untouched, so plain label and
+        slice access stays basic indexing and keeps returning views.
+
+        With a list on any axis, every axis is converted to an index array:
+        slices become arange and each list is reshaped onto its own output
+        dimension. No slices are left in the tuple, so numpy has nothing to
+        separate and the result keeps the declared axis order. Two lists select
+        the block they describe rather than its diagonal. Scalars stay scalar
+        and their axes collapse, as with basic indexing.
+
+        With pointwise=True the lists zip instead: they must share one length,
+        they are consumed together along one output axis placed where the first
+        list appears, and the remaining axes keep declared order. This is the
+        old broadcast behaviour made explicit, for writing diagonals and
+        per-point updates that block selection cannot express.
+        """
+        has_list = any(isinstance(s, list) for s in slices)
+        if not has_list:
+            if pointwise:
+                raise ValueError("pointwise indexing needs a list of labels on at least one axis")
+            return tuple(slices)
+
+        if pointwise:
+            lengths = {len(s) for s in slices if isinstance(s, list)}
+            if len(lengths) > 1:
+                raise ValueError(
+                    f"pointwise lists must all have the same length, got lengths {sorted(lengths)}"
+                )
+            n_out = 1 + sum(1 for s in slices if isinstance(s, slice))
+        else:
+            n_out = sum(1 for s in slices if isinstance(s, (list, slice)))
+
+        out: list[Any] = []
+        dim = 0
+        point_dim = None
+        for axis, s in enumerate(slices):
+            if isinstance(s, list):
+                if pointwise:
+                    if point_dim is None:
+                        point_dim = dim
+                        dim += 1
+                    use = point_dim
+                else:
+                    use = dim
+                    dim += 1
+                shape = [1] * n_out
+                shape[use] = -1
+                out.append(np.asarray(s, dtype=int).reshape(shape))
+            elif isinstance(s, slice):
+                shape = [1] * n_out
+                shape[dim] = -1
+                out.append(np.arange(self._data.shape[axis]).reshape(shape))
+                dim += 1
+            else:
+                out.append(s)
+        return tuple(out)
+
+    @property
+    def points(self) -> "_PointwiseView":
+        """Positional pointwise indexing, the zip counterpart of block access.
+
+        d.points[["A", "B"], ["C", "D"], "up"] reads or writes the two entries
+        (A, C, up) and (B, D, up) rather than the 2 by 2 block. Lists zip along
+        one shared axis and must have equal lengths.
+        """
+        return _PointwiseView(self)
 
     def _get_slices(self, keys: dict | None, indices: dict, full_indices: dict) -> list[Any]:
         slices = []
@@ -77,7 +176,7 @@ class Distribution:
         else:
             return index_map[key]
 
-    def _get_index_from_axis(self, axis: int, element: Any) -> int | slice:
+    def _get_index_from_axis(self, axis: int, element: Any) -> int | slice | list[int]:
         if isinstance(element, slice):
             return slice(None)
         if axis < len(self.event):
@@ -86,29 +185,79 @@ class Distribution:
         else:
             key = list(self.batch.keys())[axis - len(self.event)]
             index_map = self.batch_indices[key]
+        if isinstance(element, list):
+            return [self._get_index(v, index_map) for v in element]
         return self._get_index(element, index_map)
 
-    def __getitem__(self, indices: Any) -> np.ndarray:
+    def _positional_slices(self, indices: Any) -> list[Any]:
+        """Resolve a bracket index tuple to one entry per axis.
+
+        Keys are positional over the event axes and then the batch axes. An
+        event axis and a batch axis may share a key name while carrying
+        different label orders, so axes are resolved by position and never by
+        name. Axes left off the end of the tuple are taken whole.
+
+        Both bracket paths use this, so d[...] and d.points[...] accept the
+        same keys and differ only in how the lists are consumed.
+        """
         if not isinstance(indices, tuple):
             indices = (indices,)
-        index_list = [
-            self._get_index_from_axis(i, idx) for i, idx in enumerate(indices)
+        n_axes = len(self.event) + len(self.batch)
+        if len(indices) > n_axes:
+            raise IndexError(
+                f"too many indices for Distribution: it has {n_axes} axes, "
+                f"but {len(indices)} were indexed"
+            )
+        out = [
+            self._get_index_from_axis(axis, element)
+            for axis, element in enumerate(indices)
         ]
-        return self._data[tuple(index_list)]
+        out.extend([slice(None)] * (n_axes - len(indices)))
+        return out
+
+    def __getitem__(self, indices: Any) -> np.ndarray:
+        """Read by label. Lists select the block they name, as get does."""
+        slices = self._positional_slices(indices)
+        return self._data[self._index(slices, pointwise=False)]
 
     def __setitem__(self, indices: Any, value: Any) -> None:
-        if not isinstance(indices, tuple):
-            indices = (indices,)
-        index_list = [
-            self._get_index_from_axis(i, idx) for i, idx in enumerate(indices)
-        ]
-        self._data[tuple(index_list)] = value
+        """Write by label. Lists select the block they name, as set does."""
+        slices = self._positional_slices(indices)
+        self._data[self._index(slices, pointwise=False)] = value
 
     def normalize(self) -> None:
         self.data = norm_dist(self.data)
 
     def __repr__(self) -> str:
         return f"Distribution({self.event}, {self.batch})\n {self.data}"
+
+
+class _PointwiseView:
+    """Bracket access on Distribution.points.
+
+    Keys are positional over the event axes then the batch axes, the same order
+    __getitem__ uses. Labels, integers, lists of either, and bare slices are
+    accepted; lists zip rather than selecting a block. At least one axis must
+    receive a list: a selection of labels and slices alone names no points to
+    zip and raises ValueError, so d.points["A", "C", "up"] is not a way to read
+    one entry. Use d["A", "C", "up"] for that.
+    """
+
+    def __init__(self, dist: Distribution) -> None:
+        self._dist = dist
+
+    def _translate(self, indices: Any) -> list[Any]:
+        # Positional resolution is shared with Distribution's own brackets, so
+        # both accept the same keys and reject the same arities.
+        return self._dist._positional_slices(indices)
+
+    def __getitem__(self, indices: Any) -> np.ndarray:
+        slices = self._translate(indices)
+        return self._dist._data[self._dist._index(slices, pointwise=True)]
+
+    def __setitem__(self, indices: Any, values: Any) -> None:
+        slices = self._translate(indices)
+        self._dist._data[self._dist._index(slices, pointwise=True)] = values
 
 
 class DistributionIndexer(dict):

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -71,6 +71,291 @@ class TestDists(unittest.TestCase):
             np.all(transition.get({"location": "A"}, {"location": "B"}) == 1.0)
         )
 
+    def test_get_set_block_with_lists_on_two_axes(self):
+        """Lists on two axes select the block they name, in declared axis order."""
+        likelihood = distribution.Distribution(
+            {"obs": ["r", "g", "b"]}, {"state": ["s0", "s1", "s2"]}, np.arange(9.0).reshape(3, 3)
+        )
+
+        block = likelihood.get(event={"obs": ["r", "g"]}, batch={"state": ["s0", "s1"]})
+        self.assertEqual(block.shape, (2, 2))
+        self.assertTrue(np.array_equal(block, np.array([[0.0, 1.0], [3.0, 4.0]])))
+
+        likelihood.set(
+            event={"obs": ["r", "g"]}, batch={"state": ["s0", "s1"]},
+            values=np.array([[10.0, 11.0], [12.0, 13.0]]),
+        )
+        expected = np.arange(9.0).reshape(3, 3)
+        expected[:2, :2] = [[10.0, 11.0], [12.0, 13.0]]
+        self.assertTrue(np.array_equal(likelihood.data, expected))
+
+    def test_get_keeps_declared_axis_order_across_untouched_axes(self):
+        """A list after an untouched axis must not migrate to the front."""
+        transition = distribution.Distribution(
+            {"obs": ["o0", "o1", "o2"]},
+            {"state": ["s0", "s1", "s2", "s3"], "ctrl": ["up", "down"]},
+            np.arange(24.0).reshape(3, 4, 2),
+        )
+
+        got = transition.get(event={"obs": "o0"}, batch={"ctrl": ["up", "down"]})
+        self.assertEqual(got.shape, (4, 2))
+        self.assertTrue(np.array_equal(got, np.arange(24.0).reshape(3, 4, 2)[0, :, :]))
+
+        got = transition.get(event={"obs": ["o0", "o1"]}, batch={"ctrl": ["up", "down"]})
+        self.assertEqual(got.shape, (2, 4, 2))
+
+    def test_get_without_lists_returns_a_view(self):
+        likelihood = distribution.Distribution(
+            {"obs": ["r", "g", "b"]}, {"state": ["s0", "s1", "s2"]}, np.arange(9.0).reshape(3, 3)
+        )
+        got = likelihood.get(event={"obs": "r"})
+        self.assertTrue(np.shares_memory(got, likelihood.data))
+
+    def test_pointwise_zips_lists_along_one_axis(self):
+        likelihood = distribution.Distribution(
+            {"obs": ["r", "g", "b"]}, {"state": ["s0", "s1", "s2"]}, np.arange(9.0).reshape(3, 3)
+        )
+        got = likelihood.get(
+            event={"obs": ["r", "g"]}, batch={"state": ["s0", "s1"]}, pointwise=True
+        )
+        self.assertTrue(np.array_equal(got, np.array([0.0, 4.0])))
+
+        likelihood.set(
+            event={"obs": ["r", "g"]}, batch={"state": ["s0", "s1"]},
+            values=[0.9, 0.8], pointwise=True,
+        )
+        self.assertEqual(likelihood.data[0, 0], 0.9)
+        self.assertEqual(likelihood.data[1, 1], 0.8)
+        self.assertEqual(likelihood.data[0, 1], 1.0)
+
+    def test_pointwise_writes_an_off_diagonal(self):
+        """An off-diagonal transition: up moves one location back and stops at the top."""
+        locs = ["l0", "l1", "l2", "l3"]
+        transition = distribution.Distribution(
+            {"loc": locs}, {"loc": locs, "ctrl": ["up", "down"]}, np.zeros((4, 4, 2))
+        )
+        transition.set(
+            event={"loc": ["l0", "l0", "l1", "l2"]},
+            batch={"loc": ["l0", "l1", "l2", "l3"], "ctrl": "up"},
+            values=1.0, pointwise=True,
+        )
+        up = transition.data[:, :, 0]
+        self.assertTrue(np.array_equal(up.sum(axis=0), np.ones(4)))
+        self.assertEqual(up[0, 0], 1.0)
+        self.assertEqual(up[0, 1], 1.0)
+        self.assertEqual(up[1, 2], 1.0)
+        self.assertEqual(up[2, 3], 1.0)
+        self.assertTrue(np.array_equal(transition.data[:, :, 1], np.zeros((4, 4))))
+
+    def test_points_accessor_round_trip(self):
+        likelihood = distribution.Distribution(
+            {"obs": ["A", "B", "E"]}, {"state": ["C", "D", "F"], "ctrl": ["up", "down"]},
+            np.zeros((3, 3, 2)),
+        )
+        likelihood.points[["A", "B"], ["C", "D"], "up"] = [0.9, 0.8]
+        got = likelihood.points[["A", "B"], ["C", "D"], "up"]
+        self.assertTrue(np.array_equal(got, np.array([0.9, 0.8])))
+        self.assertAlmostEqual(float(likelihood.data.sum()), 1.7)
+
+    def test_points_zip_axis_position_with_a_slice(self):
+        """The zip axis sits where the first list appears; a slice keeps its own axis."""
+        likelihood = distribution.Distribution(
+            {"obs": ["A", "B", "E"]}, {"state": ["C", "D", "F"], "ctrl": ["up", "down"]},
+            np.arange(18.0).reshape(3, 3, 2),
+        )
+        got = likelihood.points[["A", "B"], :, "up"]
+        self.assertEqual(got.shape, (2, 3))
+        base = np.arange(18.0).reshape(3, 3, 2)
+        self.assertTrue(np.array_equal(got, np.stack([base[0, :, 0], base[1, :, 0]])))
+
+    def test_points_resolves_shared_key_names_by_axis(self):
+        """An event and a batch axis sharing a key name must resolve independently."""
+        shared = distribution.Distribution(
+            {"loc": ["a", "b"]}, {"loc": ["b", "a"]}, np.zeros((2, 2))
+        )
+        shared.data[0, 1] = 1.0
+        self.assertTrue(
+            np.array_equal(shared.points[["a"], ["a"]], np.array([1.0]))
+        )
+        got = shared.get(event={"loc": ["a"]}, batch={"loc": ["a"]}, pointwise=True)
+        self.assertTrue(np.array_equal(got, np.array([1.0])))
+
+    def test_pointwise_ragged_lists_raise(self):
+        likelihood = distribution.Distribution(
+            {"obs": ["r", "g", "b"]}, {"state": ["s0", "s1", "s2"]}, np.zeros((3, 3))
+        )
+        with self.assertRaisesRegex(ValueError, r"same length, got lengths \[2, 3\]"):
+            likelihood.get(
+                event={"obs": ["r", "g"]}, batch={"state": ["s0", "s1", "s2"]}, pointwise=True
+            )
+        with self.assertRaisesRegex(ValueError, "needs a list of labels on at least one axis"):
+            likelihood.get(event={"obs": "r"}, pointwise=True)
+        with self.assertRaisesRegex(ValueError, "needs a list of labels on at least one axis"):
+            likelihood.points["r", "s0"]
+
+    def test_brackets_select_the_block_lists_name(self):
+        """Lists in brackets select a block, the same one get and set select."""
+        likelihood = distribution.Distribution(
+            {"obs": ["r", "g", "b"]}, {"state": ["s0", "s1", "s2"]}, np.arange(9.0).reshape(3, 3)
+        )
+
+        block = likelihood[["r", "g"], ["s0", "s1"]]
+        self.assertEqual(block.shape, (2, 2))
+        self.assertTrue(np.array_equal(block, np.array([[0.0, 1.0], [3.0, 4.0]])))
+        self.assertTrue(
+            np.array_equal(
+                block, likelihood.get(event={"obs": ["r", "g"]}, batch={"state": ["s0", "s1"]})
+            )
+        )
+
+        likelihood[["r", "g"], ["s0", "s1"]] = np.array([[10.0, 11.0], [12.0, 13.0]])
+        expected = np.arange(9.0).reshape(3, 3)
+        expected[:2, :2] = [[10.0, 11.0], [12.0, 13.0]]
+        self.assertTrue(np.array_equal(likelihood.data, expected))
+
+    def test_brackets_keep_declared_axis_order_across_untouched_axes(self):
+        """A list after an untouched axis must not migrate to the front."""
+        transition = distribution.Distribution(
+            {"obs": ["o0", "o1", "o2"]},
+            {"state": ["s0", "s1", "s2", "s3"], "ctrl": ["up", "down"]},
+            np.arange(24.0).reshape(3, 4, 2),
+        )
+        got = transition[["o0", "o1"], :, ["up", "down"]]
+        self.assertEqual(got.shape, (2, 4, 2))
+        self.assertTrue(
+            np.array_equal(
+                got, transition.get(event={"obs": ["o0", "o1"]}, batch={"ctrl": ["up", "down"]})
+            )
+        )
+
+    def test_brackets_without_lists_return_a_view(self):
+        transition = distribution.Distribution(
+            {"obs": ["o0", "o1", "o2"]},
+            {"state": ["s0", "s1", "s2", "s3"], "ctrl": ["up", "down"]},
+            np.arange(24.0).reshape(3, 4, 2),
+        )
+        self.assertTrue(np.shares_memory(transition["o0"], transition.data))
+        self.assertTrue(np.shares_memory(transition[:, "s1", :], transition.data))
+
+    def test_set_keeps_declared_axis_order_across_untouched_axes(self):
+        """set writes into the block in declared order, label order included."""
+        transition = distribution.Distribution(
+            {"obs": ["o0", "o1", "o2"]},
+            {"state": ["s0", "s1", "s2", "s3"], "ctrl": ["up", "down"]},
+            np.zeros((3, 4, 2)),
+        )
+        values = np.arange(100.0, 116.0).reshape(2, 4, 2)
+        transition.set(
+            event={"obs": ["o0", "o1"]}, batch={"ctrl": ["down", "up"]}, values=values
+        )
+
+        expected = np.zeros((3, 4, 2))
+        expected[:2, :, 1] = values[:, :, 0]
+        expected[:2, :, 0] = values[:, :, 1]
+        self.assertTrue(np.array_equal(transition.data, expected))
+
+    def test_block_set_broadcasts_values_across_the_block(self):
+        """Lists on two axes write the whole block; pointwise=True writes the diagonal."""
+        locs = ["l0", "l1", "l2", "l3"]
+
+        block = distribution.Distribution(
+            {"loc": locs}, {"loc": locs, "ctrl": ["up", "down"]}, np.zeros((4, 4, 2))
+        )
+        block.set(event={"loc": locs}, batch={"loc": locs, "ctrl": "up"}, values=np.ones(4))
+        self.assertTrue(np.array_equal(block.data[:, :, 0], np.ones((4, 4))))
+        self.assertTrue(np.array_equal(block.data[:, :, 1], np.zeros((4, 4))))
+
+        diagonal = distribution.Distribution(
+            {"loc": locs}, {"loc": locs, "ctrl": ["up", "down"]}, np.zeros((4, 4, 2))
+        )
+        diagonal.set(
+            event={"loc": locs}, batch={"loc": locs, "ctrl": "up"},
+            values=np.ones(4), pointwise=True,
+        )
+        self.assertTrue(np.array_equal(diagonal.data[:, :, 0], np.eye(4)))
+
+    def test_pointwise_set_values_orientation_with_a_leading_slice(self):
+        """The zip axis sits where the first list appears, after the slice's own axis."""
+        likelihood = distribution.Distribution(
+            {"obs": ["A", "B", "E"]}, {"state": ["C", "D", "F"], "ctrl": ["up", "down"]},
+            np.zeros((3, 3, 2)),
+        )
+        values = np.arange(6.0).reshape(3, 2)
+        likelihood.points[:, ["C", "D"], "up"] = values
+
+        self.assertTrue(np.array_equal(likelihood.points[:, ["C", "D"], "up"], values))
+        self.assertTrue(np.array_equal(likelihood.data[:, 0, 0], values[:, 0]))
+        self.assertTrue(np.array_equal(likelihood.data[:, 1, 0], values[:, 1]))
+        self.assertEqual(likelihood.data[:, 2, :].sum(), 0.0)
+
+        with self.assertRaises(ValueError):
+            likelihood.points[:, ["C", "D"], "up"] = values.T
+
+        through_set = distribution.Distribution(
+            {"obs": ["A", "B", "E"]}, {"state": ["C", "D", "F"], "ctrl": ["up", "down"]},
+            np.zeros((3, 3, 2)),
+        )
+        through_set.set(
+            batch={"state": ["C", "D"], "ctrl": "up"}, values=values, pointwise=True
+        )
+        self.assertTrue(np.array_equal(through_set.data, likelihood.data))
+
+        with self.assertRaises(ValueError):
+            through_set.set(
+                batch={"state": ["C", "D"], "ctrl": "up"}, values=values.T, pointwise=True
+            )
+
+        two_lists = distribution.Distribution(
+            {"obs": ["A", "B", "E"]}, {"state": ["C", "D", "F"], "ctrl": ["up", "down"]},
+            np.zeros((3, 3, 2)),
+        )
+        paired = np.arange(10.0, 16.0).reshape(3, 2)
+        two_lists.set(
+            batch={"state": ["C", "D"], "ctrl": ["up", "down"]},
+            values=paired, pointwise=True,
+        )
+        self.assertTrue(np.array_equal(two_lists.data[:, 0, 0], paired[:, 0]))
+        self.assertTrue(np.array_equal(two_lists.data[:, 1, 1], paired[:, 1]))
+        self.assertEqual(two_lists.data.sum(), paired.sum())
+
+    def test_pointwise_with_one_list_matches_block_selection(self):
+        likelihood = distribution.Distribution(
+            {"obs": ["r", "g", "b"]}, {"state": ["s0", "s1", "s2"]}, np.arange(9.0).reshape(3, 3)
+        )
+        got = likelihood.get(event={"obs": ["r", "g"]}, pointwise=True)
+        self.assertEqual(got.shape, (2, 3))
+        self.assertTrue(np.array_equal(got, np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])))
+        self.assertTrue(np.array_equal(got, likelihood.get(event={"obs": ["r", "g"]})))
+
+    def test_points_accepts_int_and_mixed_labels(self):
+        likelihood = distribution.Distribution(
+            {"obs": ["A", "B", "E"]}, {"state": ["C", "D", "F"], "ctrl": ["up", "down"]},
+            np.arange(18.0).reshape(3, 3, 2),
+        )
+        by_label = likelihood.points[["A", "B"], ["C", "D"], "up"]
+        self.assertTrue(np.array_equal(by_label, np.array([0.0, 8.0])))
+        self.assertTrue(np.array_equal(likelihood.points[[0, 1], [0, 1], 0], by_label))
+        self.assertTrue(np.array_equal(likelihood.points[[0, "B"], ["C", 1], "up"], by_label))
+
+    def test_too_many_indices_names_the_axis_count(self):
+        likelihood = distribution.Distribution(
+            {"obs": ["r", "g", "b"]}, {"state": ["s0", "s1", "s2"]}, np.zeros((3, 3))
+        )
+        with self.assertRaisesRegex(IndexError, "it has 2 axes, but 3 were indexed"):
+            likelihood["r", "s0", :]
+        with self.assertRaisesRegex(IndexError, "it has 2 axes, but 3 were indexed"):
+            likelihood.points[["r", "g"], ["s0", "s1"], :]
+
+    def test_pointwise_is_keyword_only(self):
+        likelihood = distribution.Distribution(
+            {"obs": ["r", "g", "b"]}, {"state": ["s0", "s1", "s2"]}, np.zeros((3, 3))
+        )
+        with self.assertRaises(TypeError):
+            likelihood.get({"state": ["s0", "s1"]}, {"obs": ["r", "g"]}, True)
+        with self.assertRaises(TypeError):
+            likelihood.set({"state": ["s0", "s1"]}, {"obs": ["r", "g"]}, 1.0, True)
+        self.assertEqual(likelihood.data.sum(), 0.0)
+
     def test_agent_compile(self):
         model_example = {
             "observations": {

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -345,6 +345,8 @@ class TestDists(unittest.TestCase):
             likelihood["r", "s0", :]
         with self.assertRaisesRegex(IndexError, "it has 2 axes, but 3 were indexed"):
             likelihood.points[["r", "g"], ["s0", "s1"], :]
+        with self.assertRaisesRegex(IndexError, "it has 2 axes, but 3 were indexed"):
+            likelihood["r", "s0", "s1"]
 
     def test_pointwise_is_keyword_only(self):
         likelihood = distribution.Distribution(


### PR DESCRIPTION
Fixes #424.

Implements the conversion described there: when any axis receives a list,
every axis becomes an index array. Slices turn into arange, each list is
reshaped onto its own output dimension, and no slices are left in the tuple,
so there is nothing for numpy to separate. Two lists now select the block
they name, and the declared axis order survives an untouched axis sitting
between advanced indices, which also fixes the reordering effect from the
issue. The gate is "at least one list present", so plain label and slice
access stays basic indexing, and a test pins that it still returns views.

The zip behaviour stays available where it is the point rather than the bug.
get and set take pointwise=True, and a points accessor covers bracket style
access:

```python
B["s1"].points[["A", "B"], ["C", "D"], "up"] = [0.9, 0.8]
```

Lists zip along one shared axis placed where the first list appears, the
remaining axes keep declared order, and ragged lists raise ValueError instead
of broadcasting into something surprising. The banded transition from the
issue thread works and is in the tests:

```python
transition.set(
    event={"loc": ["l0", "l0", "l1", "l2"]},
    batch={"loc": ["l0", "l1", "l2", "l3"], "ctrl": "up"},
    values=1.0, pointwise=True,
)
```

Bracket indexing takes lists as well, with the same block default, so
`d[["r", "g"], ["s0", "s1"]]` and the equivalent get call select the same
entries. Both bracket paths share one positional resolution step, so `d[...]`
and `d.points[...]` resolve the same keys against the same axes and reject the
same arities. They still differ in what they require: points needs a list on
at least one axis and raises without one, while brackets take a selection of
labels and slices alone. pointwise is keyword only on get and set, because
values is the third positional argument of set and pointwise was the third of
get, so mirroring a get call in set bound True to values. Indexing more axes
than the distribution has raises one named error from both bracket paths,
where the message used to depend on the path and on the kind of extra index.

One migration hazard is documented on set and pinned by a test. With block
selection, `set(event={"loc": locs}, batch={"loc": locs, "ctrl": "up"},
values=np.ones(4))` broadcasts the value into every row and fills all 16
entries of the 4 by 4 block. The same expression wrote the 4 diagonal entries
before, and pointwise=True still writes them.

Nineteen tests added to TestDists: the two axis block with a set round trip,
declared order across an untouched axis for get and for set, the view
guarantee on the no list path for get and for brackets, pointwise get and
set, the banded example, the points round trip, the zip axis position with a
slice in the selection, values orientation for a pointwise set whose first
list follows a slice, one list with pointwise=True, int and mixed labels
through points, an event and a batch axis sharing a key name with different
label orders, blocks through brackets with a set round trip and declared
order, the broadcast above against the diagonal pointwise=True writes,
pointwise refused positionally, and the ragged, no list and too many indices
error cases.

This branch's test file run against main's source gives 7 passed and 16
failed, against 23 passed here. ruff check with the repo config and the
version pinned in #441 (0.15.22 here) reports no findings on main or on this
branch.
