### PR TITLE
deps: pin jax/jaxlib <0.11.1 pending numpyro fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,12 @@ classifiers=[
 requires-python = ">=3.10"
 dependencies = [
     'numpy>=1.19.5',
-    'jax>=0.3.4',
-    'jaxlib>=0.3.4',
+    # jax/jaxlib upper-bounded until numpyro supports jax 0.11.1, which moves
+    # closed-over constants from jaxpr.constvars into jaxpr.invars. numpyro's
+    # eval_provenance zips jaxpr.invars against the explicit kwargs only, so it
+    # trips a length assertion. Reached via pybefit -> numpyro. See issue #447.
+    'jax>=0.3.4,<0.11.1',
+    'jaxlib>=0.3.4,<0.11.1',
     'equinox>=0.9',
     'multimethod>=1.11',
     'matplotlib>=3.1.3',
@@ -62,7 +66,7 @@ test = [
 
 [project.optional-dependencies]
 gpu = [
-    'jax[cuda12]>=0.3.4',
+    'jax[cuda12]>=0.3.4,<0.11.1',
 ]
 docs = [
     "mkdocs>=1.6.1,<2",


### PR DESCRIPTION
Fixes #447.

jax 0.11.1 moves closed-over constants out of `jaxpr.constvars` and into `jaxpr.invars`. numpyro's `eval_provenance` zips `jaxpr.invars` against the explicit kwargs only, so `_safe_map` trips its length assertion. Reached via pybefit -> numpyro, so it hits every pybefit-using test.

Same shape as #391/#404 (and the same numpyro module as #389), so this follows that pattern: upper-bound `jax`/`jaxlib` in `dependencies` plus the `gpu` extra, with a comment pointing at the tracking issue, and revert once a patched numpyro ships.

## Why this is not a one-notebook problem

It fails the unit suite, not just the nightly notebooks, which is why every open PR is currently red:

```
FAILED test/test_tmaze_recoverability.py::test_tmaze_recoverability_three_param_smoke - AssertionError: length mismatch: [15, 1]
FAILED test/test_tmaze_recoverability.py::test_tmaze_recoverability_reward_only_smoke - AssertionError: length mismatch: [15, 1]
```

Confirmed PR-independent: #442 and #445 fail identically on different files by different authors, and it reproduces on pristine main at CI's resolved versions.

## Verification

On main (5848360), python 3.13, numpyro 0.21.0 held constant:

| jax | `test/test_tmaze_recoverability.py` |
|---|---|
| 0.11.1 | 2 failed |
| 0.11.0 | 2 passed |

With this pin applied, resolution lands on jax 0.11.0 and the full suite is green: **308 passed, 78 subtests passed**.

## Note on why this keeps happening

CI has no lockfile (`uv.lock` is gitignored), so every run re-resolves and picks up new jax releases the day they ship. That is deliberate — a committed lock would be platform-specific — but it does mean upstream breakage lands inside unrelated PRs rather than somewhere it can be triaged. Worth considering a scheduled job that re-resolves against latest and reports, separately from this fix.
