### PR TITLE
fix: warn when flattened B action dependencies conflict with sampling_mode

### DIFF
--- a/pymdp/agent.py
+++ b/pymdp/agent.py
@@ -219,7 +219,26 @@ class Agent(Module):
             )
             B, pB, self.action_maps = self._flatten_B_action_dims(B, pB, self.B_action_dependencies)
             policies = self._construct_flattend_policies_tuple(policies_multi_tup, self.action_maps)
-            self.sampling_mode = "full"
+            # Flattening the action dimensions collapses the control factors into a
+            # single joint action space. That is the space `sampling_mode="full"`
+            # indexes against (`unique_multiactions`), whereas `"marginal"` reasons
+            # about the un-flattened factors, so the two modes no longer describe the
+            # same action space here.
+            #
+            # This branch used to assign `self.sampling_mode = "full"`, but that
+            # assignment was dead: the constructor parameter is written to
+            # `self.sampling_mode` below and always won, so the request was honoured
+            # and the deliberate override never took effect. Warn instead of
+            # overriding, so the conflict is visible without changing which mode is
+            # used. See issue #434.
+            if sampling_mode != "full":
+                warnings.warn(
+                    "`B_action_dependencies` flattens the control factors into a single "
+                    "joint action space, which `sampling_mode='full'` is designed for; got "
+                    f"sampling_mode={sampling_mode!r}. Action selection will follow the "
+                    "requested mode. Pass sampling_mode='full' to silence this warning.",
+                    stacklevel=2,
+                )
         
         # extract shapes from A and B
         self.num_states = self._get_num_states_from_B(B, self.B_dependencies)

--- a/test/test_agent_jax.py
+++ b/test/test_agent_jax.py
@@ -6,6 +6,7 @@ __author__: Dimitrije Markovic, Conor Heins
 """
 
 import unittest
+import warnings
 from functools import partial
 from types import SimpleNamespace
 
@@ -103,6 +104,61 @@ class TestAgentJax(unittest.TestCase):
         self.assertTrue(agent.num_controls == num_controls_flattened)
 
             
+    def test_flattened_action_dependencies_warn_on_incompatible_sampling_mode(self):
+        """
+        `B_action_dependencies` flatten the control factors into a single joint action
+        space, which is the space `sampling_mode="full"` indexes against; `"marginal"`
+        reasons about the un-flattened factors instead. The flattening branch used to
+        try to force `"full"` by assigning `self.sampling_mode`, but that assignment was
+        dead -- the constructor parameter is written to `self.sampling_mode` afterwards
+        and always won -- so a conflicting request was honoured with no indication.
+        It should now warn, without changing which mode is used.
+        """
+        num_obs = [2, 3]
+        num_states = [4, 5, 2]
+        num_controls = [2, 3, 2]
+        A_dependencies = [[0, 1], [1]]
+        B_dependencies = [[0], [0, 1, 2], [2]]
+        B_action_dependencies = [[], [0, 1], [0, 2]]
+
+        a_key, b_key = jr.PRNGKey(0), jr.PRNGKey(1)
+
+        def build(sampling_mode):
+            A = utils.random_A_array(
+                a_key, num_obs, num_states, A_dependencies=A_dependencies
+            )
+            B = utils.random_B_array(
+                b_key,
+                num_states,
+                num_controls,
+                B_dependencies=B_dependencies,
+                B_action_dependencies=B_action_dependencies,
+            )
+            return Agent(
+                A,
+                B,
+                A_dependencies=A_dependencies,
+                B_dependencies=B_dependencies,
+                B_action_dependencies=B_action_dependencies,
+                num_controls=num_controls,
+                sampling_mode=sampling_mode,
+            )
+
+        # an incompatible request is reported ...
+        with self.assertWarns(UserWarning):
+            agent_marginal = build("marginal")
+        # ... and is still the mode that ends up in effect
+        self.assertEqual(agent_marginal.sampling_mode, "marginal")
+
+        # `"full"` is the mode the flattened action space is built for: no warning
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            agent_full = build("full")
+        self.assertEqual(
+            [w for w in caught if issubclass(w.category, UserWarning)], []
+        )
+        self.assertEqual(agent_full.sampling_mode, "full")
+
     def test_desired_batch_no_batched_input_construction(self):
         """
         Tests for the case where the user wants > 1 batch size, and they pass in tensors with no batch size


### PR DESCRIPTION
Refs #434 — though the diagnosis in the issue is inverted, and I think that matters for
whatever fix you actually want.

## What is actually happening

The issue reports that `agent.py:222` "silently overwrites the user's `sampling_mode` with
`"full"`", so a caller asking for `"marginal"` gets `"full"`.

That assignment is dead. `self.sampling_mode = "full"` at line 222 is unconditionally
overwritten by `self.sampling_mode = sampling_mode` at line 286, which is the constructor
parameter. So the opposite is true: the caller's request is honoured, and the *flattening
branch's deliberate override never takes effect*.

Reproduced on current `main` (`057841d`) with the multi-action setup already used in
`test_agent_jax.py`:

```python
B_action_dependencies = [[], [0, 1], [0, 2]]   # non-trivial -> flattening branch runs
# A/B built with B_dependencies = [[0], [0, 1, 2], [2]], num_controls = [2, 3, 2]

Agent(..., sampling_mode="full")      -> agent.sampling_mode == "full"
Agent(..., sampling_mode="marginal")  -> agent.sampling_mode == "marginal"
```

## Why the conflict is real

`_flatten_B_action_dims` collapses the control factors into one joint action space. That is
the space `"full"` indexes against — it matches `policies.policy_arr[:, 0]` against
`unique_multiactions`. `"marginal"` instead calls `control.get_marginals` over the
un-flattened factors. Once the dimensions are flattened the two modes no longer describe the
same action space, which is what the comment on line 210–212 is getting at. So line 222 was
trying to say something true; it just never got applied.

## What this PR does

Emits a warning when the flattening branch runs with `sampling_mode != "full"`, and drops the
dead assignment.

I deliberately did **not** make the override effective. Making `"full"` win would change
behaviour for anyone currently passing `"marginal"` with flattened action dependencies, and I
could not show that the current outcome is numerically wrong — with a uniform policy
posterior both modes return the same action vector, they just aggregate the posterior
differently. Changing numerics under someone's feet is your call, not mine, so this PR only
removes the silence. If you would rather enforce `"full"`, it is a two-line change: resolve
`sampling_mode` after the parameter assignment and warn on the difference.

## Verification

- `test_flattened_action_dependencies_warn_on_incompatible_sampling_mode` fails on `main`
  with `AssertionError: UserWarning not triggered` and passes with the change. It checks both
  directions: the incompatible request warns and keeps the requested mode, and `"full"` stays
  silent.
- `pytest test/` — **325 passed, 1 skipped**, 78 subtests passed. (The single collection error
  is `test_tmaze_recoverability.py` importing `numpyro`, which is not installed in my
  environment; unrelated to this change.)
- No existing test passes a non-default `sampling_mode` together with
  `B_action_dependencies`, so no existing test changes behaviour.
